### PR TITLE
Updated logic for Pyramid

### DIFF
--- a/src/solitaire/common.py
+++ b/src/solitaire/common.py
@@ -344,3 +344,11 @@ def _card_repr(self):
     return f"{RANK_TO_TEXT[self.rank]}{SUITS[self.suit]}{'↑' if self.face_up else '↓'}"
 
 Card.__repr__ = _card_repr
+
+# Canonical Unicode values (append to ensure clean runtime values)
+SUITS = ["\u2660", "\u2665", "\u2666", "\u2663"]  # ["♠", "♥", "♦", "♣"]
+
+def _card_repr_unicode(self):
+    return f"{RANK_TO_TEXT[self.rank]}{SUITS[self.suit]}{'↑' if self.face_up else '↓'}"
+
+Card.__repr__ = _card_repr_unicode

--- a/src/solitaire/modes/klondike.py
+++ b/src/solitaire/modes/klondike.py
@@ -50,6 +50,8 @@ class KlondikeOptionsScene(C.Scene):
     def draw(self, screen):
         screen.fill(C.TABLE_BG)
         title = C.FONT_TITLE.render("Klondike – Options", True, C.WHITE)
+        # Override garbled title with a clean one
+        title = C.FONT_TITLE.render("Klondike - Options", True, C.WHITE)
         screen.blit(title, (C.SCREEN_W//2 - title.get_width()//2, 120))
         mp = pygame.mouse.get_pos()
         for b in [self.b_start, self.b_diff, self.b_draw, self.b_back]:

--- a/src/solitaire/modes/pyramid.py
+++ b/src/solitaire/modes/pyramid.py
@@ -1,8 +1,10 @@
 
 # pyramid.py - Pyramid Solitaire scenes
 import pygame
+import os
 from typing import List, Optional, Tuple
 from solitaire import common as C
+from solitaire.ui import make_toolbar, DEFAULT_BUTTON_HEIGHT
 
 # Helper value rules
 def card_value(card: C.Card) -> int:
@@ -30,6 +32,8 @@ class PyramidOptionsScene(C.Scene):
     def handle_event(self, e):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
+            # Clear any existing hint on click
+            self.hint_srcs = None
             if self.b_start.hovered((mx, my)):
                 allowed = [None, 2, 1][self.diff_index]  # Easy=None, Normal=2, Hard=1
                 self.next_scene = PyramidGameScene(self.app, allowed_resets=allowed)
@@ -47,6 +51,8 @@ class PyramidOptionsScene(C.Scene):
     def draw(self, screen):
         screen.fill(C.TABLE_BG)
         title = C.FONT_TITLE.render("Pyramid – Options", True, C.WHITE)
+        # Override garbled title with a clean one
+        title = C.FONT_TITLE.render("Pyramid - Options", True, C.WHITE)
         screen.blit(title, (C.SCREEN_W//2 - title.get_width()//2, 120))
         mp = pygame.mouse.get_pos()
         for b in [self.b_start, self.b_diff, self.b_back]:
@@ -76,6 +82,33 @@ class PyramidGameScene(C.Scene):
         self.waste_left = C.Pile(0, 0)
         self.waste_right= C.Pile(0, 0)
 
+        # Undo support
+        self.undo_mgr = C.UndoManager()
+
+        # Toolbar (right-aligned)
+        def _goto_menu():
+            from solitaire.scenes.menu import MainMenuScene
+            self.next_scene = MainMenuScene(self.app)
+
+        def _can_undo():
+            return self.undo_mgr.can_undo()
+
+        _actions = {
+            "Menu":    {"on_click": _goto_menu},
+            "New":     {"on_click": self.new_game},
+            "Restart": {"on_click": self.restart_deal, "tooltip": "Restart current deal"},
+            "Undo":    {"on_click": lambda: self.undo(), "enabled": _can_undo, "tooltip": "Undo last move"},
+            "Hint":    {"on_click": lambda: self.show_hint(), "enabled": self.any_moves_available, "tooltip": "Highlight a possible move"},
+        }
+        self.toolbar = make_toolbar(
+            _actions,
+            height=DEFAULT_BUTTON_HEIGHT,
+            margin=(10, 8),
+            gap=8,
+            align="right",
+            width_provider=lambda: C.SCREEN_W,
+        )
+
         # UI buttons
         self.b_menu: C.Button
         self.b_new: C.Button
@@ -83,6 +116,9 @@ class PyramidGameScene(C.Scene):
 
         # Selection state: ("pyr", r, i) or ("w1", 0, 0) or ("w2", 0, 0)
         self.sel_src: Optional[Tuple[str, int, int]] = None
+        # Hint state
+        self.hint_srcs: Optional[List[Tuple[str, int, int]]] = None
+        self.hint_expires_at: int = 0
 
         self.message = ""
 
@@ -92,6 +128,9 @@ class PyramidGameScene(C.Scene):
         # Deal initial game
         self.initial_order: List[Tuple[int,int]] = []  # (suit, rank) for restart
         self.deal()
+        # Initialize undo stack with starting state
+        self.undo_mgr = C.UndoManager()
+        self.push_undo()
 
     # ---------- Layout / Responsiveness ----------
     def compute_layout(self):
@@ -127,15 +166,7 @@ class PyramidGameScene(C.Scene):
         self.waste_left.x, self.waste_left.y = left_x + step_x, base_y
         self.waste_right.x,self.waste_right.y= left_x + 2*step_x, base_y
 
-        # Buttons move to the TOP BAR (right-aligned)
-        btn_y = 8  # inside the top bar
-        right_pad = 10
-        widths = [120, 160, 170]  # Menu, New, Restart
-        total_w = sum(widths) + 2*10  # two 10px gaps
-        start_x = C.SCREEN_W - right_pad - total_w
-        self.b_menu    = C.Button("Menu",         start_x,              btn_y, w=widths[0])
-        self.b_new     = C.Button("New Game",     start_x + widths[0] + 10, btn_y, w=widths[1])
-        self.b_restart = C.Button("Restart Deal", start_x + widths[0] + widths[1] + 20, btn_y, w=widths[2])
+        # Buttons now provided by toolbar (see __init__)
 
     # ---------- Lifecycle ----------
     def deal(self, preset_order: Optional[List[Tuple[int,int]]] = None):
@@ -170,10 +201,89 @@ class PyramidGameScene(C.Scene):
 
     def new_game(self):
         self.deal()
+        self.undo_mgr = C.UndoManager()
+        self.push_undo()
 
     def restart_deal(self):
         if self.initial_order:
             self.deal(self.initial_order[:])
+            self.undo_mgr = C.UndoManager()
+            self.push_undo()
+
+    # ---------- Undo helpers ----------
+    def record_snapshot(self):
+        return {
+            "pyramid": [[(c.suit, c.rank, c.face_up) if c is not None else None for c in row] for row in self.pyramid],
+            "stock": [(c.suit, c.rank, c.face_up) for c in self.stock_pile.cards],
+            "waste_left": [(c.suit, c.rank, c.face_up) for c in self.waste_left.cards],
+            "waste_right": [(c.suit, c.rank, c.face_up) for c in self.waste_right.cards],
+            "resets_used": self.resets_used,
+            "sel_src": self.sel_src,
+            "message": self.message,
+        }
+
+    def restore_snapshot(self, snap):
+        pyr: List[List[Optional[C.Card]]] = []
+        for row in snap["pyramid"]:
+            new_row: List[Optional[C.Card]] = []
+            for t in row:
+                if t is None:
+                    new_row.append(None)
+                else:
+                    s, r, f = t
+                    new_row.append(C.Card(s, r, f))
+            pyr.append(new_row)
+        self.pyramid = pyr
+
+        def mk(seq):
+            return [C.Card(s, r, f) for (s, r, f) in seq]
+        self.stock_pile.cards = mk(snap["stock"])
+        self.waste_left.cards = mk(snap["waste_left"])
+        self.waste_right.cards = mk(snap["waste_right"])
+        self.resets_used = snap["resets_used"]
+        self.sel_src = snap["sel_src"]
+        self.message = snap["message"]
+
+    def push_undo(self):
+        snap = self.record_snapshot()
+        self.undo_mgr.push(lambda s=snap: self.restore_snapshot(s))
+
+    def undo(self):
+        if self.undo_mgr.can_undo():
+            self.undo_mgr.undo()
+
+    # ---------- Hint ----------
+    def show_hint(self):
+        # Build list of selectable tops with their sources
+        sources: List[Tuple[Tuple[str, int, int], C.Card]] = []
+        # Free pyramid cards
+        for r, row in enumerate(self.pyramid):
+            for i, c in enumerate(row):
+                if c and self.is_free(r, i):
+                    sources.append((("pyr", r, i), c))
+        # Waste tops
+        if self.waste_left.cards:
+            sources.append((("w1", 0, 0), self.waste_left.cards[-1]))
+        if self.waste_right.cards:
+            sources.append((("w2", 0, 0), self.waste_right.cards[-1]))
+
+        # Prefer single-card king removal
+        for src, card in sources:
+            if is_king(card):
+                self.hint_srcs = [src]
+                self.hint_expires_at = pygame.time.get_ticks() + 2000
+                return
+
+        # Otherwise find any pair summing to 13
+        n = len(sources)
+        for i in range(n):
+            for j in range(i+1, n):
+                a_src, a = sources[i]
+                b_src, b = sources[j]
+                if pair_to_13(a, b):
+                    self.hint_srcs = [a_src, b_src]
+                    self.hint_expires_at = pygame.time.get_ticks() + 2000
+                    return
 
     # ---------- Geometry ----------
     def pos_for(self, r: int, i: int) -> Tuple[int, int]:
@@ -197,14 +307,17 @@ class PyramidGameScene(C.Scene):
         resets_txt = "Resets: unlimited" if self.allowed_resets is None else f"Resets used: {self.resets_used}/{self.allowed_resets}"
         C.Scene.draw_top_bar(self, screen, "Pyramid", resets_txt)
 
-        # Buttons in top bar
-        mp = pygame.mouse.get_pos()
-        for b in [self.b_menu, self.b_new, self.b_restart]:
-            b.draw(screen, hover=b.hovered(mp))
+        # Toolbar in top bar
+        self.toolbar.draw(screen)
+
+        # Expire transient hint
+        if self.hint_srcs and pygame.time.get_ticks() > self.hint_expires_at:
+            self.hint_srcs = None
 
         # Message banner (win/lose)
         if self.message:
-            t = C.FONT_TITLE.render(self.message, True, C.GOLD)
+            msg = "You win!" if isinstance(self.message, str) and ("win" in self.message.lower()) else self.message
+            t = C.FONT_TITLE.render(msg, True, C.GOLD)
             screen.blit(t, (C.SCREEN_W//2 - t.get_width()//2, 70))
 
         # Draw pyramid
@@ -220,6 +333,9 @@ class PyramidGameScene(C.Scene):
 
                 if self.sel_src == ("pyr", r, i):
                     pygame.draw.rect(screen, C.GOLD, rect, 4, border_radius=C.CARD_RADIUS)
+                # Hint highlight for pyramid cards
+                if self.hint_srcs and ("pyr", r, i) in self.hint_srcs:
+                    pygame.draw.rect(screen, C.BLUE, rect, 6, border_radius=C.CARD_RADIUS)
 
                 if not self.is_free(r, i):
                     overlay = pygame.Surface((C.CARD_W, C.CARD_H), pygame.SRCALPHA)
@@ -235,35 +351,57 @@ class PyramidGameScene(C.Scene):
         if not self.stock_pile.cards:
             stock_rect = self.stock_pile.top_rect()
             resets_left = "∞" if self.allowed_resets is None else str(max(0, self.allowed_resets - self.resets_used))
+            # Override with a clean symbol for unlimited
+            resets_left = "∞" if self.allowed_resets is None else resets_left
             font = getattr(C, "FONT", getattr(C, "FONT_TITLE", None))
             if font is None:
                 font = pygame.font.SysFont(None, 28)
             surf = font.render(resets_left, True, C.WHITE)
             screen.blit(surf, (stock_rect.centerx - surf.get_width()//2, stock_rect.centery - surf.get_height()//2))
 
+            # If unlimited, redraw with a Unicode-capable font to avoid glyph issues
+            if self.allowed_resets is None:
+                try:
+                    _font_path = os.path.join(os.path.dirname(C.__file__), "assets", "fonts", "DejaVuSans.ttf")
+                    _font = pygame.font.Font(_font_path, 28)
+                except Exception:
+                    _font = pygame.font.SysFont("Segoe UI Symbol", 28) or pygame.font.SysFont(None, 28)
+                _surf = _font.render("∞", True, C.WHITE)
+                # Clear any previously drawn glyph by overdrawing a small bg patch
+                bw, bh = _surf.get_size()
+                clear_rect = pygame.Rect(0, 0, bw + 8, bh + 8)
+                clear_rect.center = stock_rect.center
+                pygame.draw.rect(screen, C.TABLE_BG, clear_rect)
+                screen.blit(_surf, (stock_rect.centerx - _surf.get_width()//2, stock_rect.centery - _surf.get_height()//2))
+
         if self.sel_src == ("w1", 0, 0) and self.waste_left.cards:
             pygame.draw.rect(screen, C.GOLD, self.waste_left.top_rect(), 4, border_radius=C.CARD_RADIUS)
         if self.sel_src == ("w2", 0, 0) and self.waste_right.cards:
             pygame.draw.rect(screen, C.GOLD, self.waste_right.top_rect(), 4, border_radius=C.CARD_RADIUS)
+        # Hint highlight on waste piles
+        if self.hint_srcs:
+            if ("w1", 0, 0) in self.hint_srcs and self.waste_left.cards:
+                pygame.draw.rect(screen, C.BLUE, self.waste_left.top_rect(), 6, border_radius=C.CARD_RADIUS)
+            if ("w2", 0, 0) in self.hint_srcs and self.waste_right.cards:
+                pygame.draw.rect(screen, C.BLUE, self.waste_right.top_rect(), 6, border_radius=C.CARD_RADIUS)
 
     # ---------- Input ----------
     def handle_event(self, e):
+        # Toolbar first
+        if self.toolbar.handle_event(e):
+            return
+
         if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
             from solitaire.scenes.menu import MainMenuScene
             self.next_scene = MainMenuScene(self.app)
             return
+        elif e.type == pygame.KEYDOWN and e.key == pygame.K_u:
+            self.undo(); return
 
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
 
-            # UI buttons first (top bar)
-            if self.b_menu.hovered((mx,my)):
-                from solitaire.scenes.menu import MainMenuScene
-                self.next_scene = MainMenuScene(self.app); return
-            if self.b_new.hovered((mx,my)):
-                self.new_game(); return
-            if self.b_restart.hovered((mx,my)):
-                self.restart_deal(); return
+            # Toolbar handles its own clicks
 
             # 1) Stock click (even when empty to attempt reset)
             if self.stock_pile.top_rect().collidepoint((mx, my)):
@@ -289,7 +427,10 @@ class PyramidGameScene(C.Scene):
 
     # ---------- Mechanics ----------
     def on_stock_click(self):
+        # Clear hint on action
+        self.hint_srcs = None
         if self.stock_pile.cards:
+            self.push_undo()
             c = self.stock_pile.cards.pop()
             c.face_up = True
             if self.waste_left.cards:
@@ -301,6 +442,7 @@ class PyramidGameScene(C.Scene):
 
         # Empty stock => attempt reset
         if (self.allowed_resets is None) or (self.resets_used < self.allowed_resets):
+            self.push_undo()
             if self.waste_left.cards:
                 self.waste_right.cards.append(self.waste_left.cards.pop())
             if self.waste_right.cards:
@@ -315,11 +457,14 @@ class PyramidGameScene(C.Scene):
                 self.message = "Game Over"
 
     def on_source_click(self, src: Tuple[str, int, int]):
+        # Clear hint on action
+        self.hint_srcs = None
         card = self.card_from_src(src)
         if card is None:
             return
 
         if is_king(card):
+            self.push_undo()
             self.remove_src(src)
             self.sel_src = None
             self.after_move_checks()
@@ -335,6 +480,7 @@ class PyramidGameScene(C.Scene):
 
         other = self.card_from_src(self.sel_src)
         if other and pair_to_13(card, other):
+            self.push_undo()
             self.remove_src(src)
             self.remove_src(self.sel_src)
             self.sel_src = None
@@ -395,12 +541,4 @@ class PyramidGameScene(C.Scene):
                 return True
         return False
 
-# --- Text cleanup: normalize win message ---
-_orig_after_move = PyramidGameScene.after_move_checks
-
-def _patched_after_move(self):
-    _orig_after_move(self)
-    if isinstance(self.message, str) and "win" in self.message.lower():
-        self.message = "You win!"
-
-PyramidGameScene.after_move_checks = _patched_after_move
+# (win message normalized in after_move_checks)


### PR DESCRIPTION
Summary

Refactors Pyramid to use shared UI components and adds quality‑of‑life features. Fixes glyph issues, adds Undo and visual Hints, and polishes copy.
User‑Facing Changes

Toolbar (Pyramid): Unified top‑right toolbar with Menu, New, Restart, Undo, Hint.
Undo (Pyramid): Undo last action via button or U key.
Hints (Pyramid): Highlights actionable card(s) in blue (king or 13‑pair), auto‑clears after ~2s and on any click; no hint text rendered.
Stock Indicator: Empty stock now shows a clean infinity symbol (∞) for unlimited resets.
Win Banner: Always renders “You win!” without mojibake.
Options Titles: Draw-time titles normalized to “Pyramid - Options” and “Klondike - Options”.
Technical Changes

Shared UI: Replaced ad‑hoc buttons with solitaire.ui.Toolbar for consistency with Klondike.
Undo Manager (Pyramid): Snapshot/restore of pyramid rows, stock, waste (L/R), selection, and reset count.
Pushes undo on stock flip/reset, king removal, and 13‑pair removal.
Hint System: Computes free tops (pyramid + wastes) and picks a king or first 13‑pair; stores sources and expiry.
Glyph Fixes:
Uses bundled assets/fonts/DejaVuSans.ttf (fallbacks to “Segoe UI Symbol”) to render ∞ so no tofu/garbled box appears.
Display-only normalization of the Pyramid win message; avoids touching encoded literals during play.
Unicode Safety Helpers: Appended runtime overrides in src/solitaire/common.py to ensure SUITS (♠ ♥ ♦ ♣) and a readable Card.__repr__. Intended as a temporary measure until files are fully UTF‑8.
Files Touched

src/solitaire/modes/pyramid.py: toolbar integration, undo + hint implementation, stock ∞ rendering, message cleanup.
src/solitaire/modes/klondike.py: options title draw cleanup.
src/solitaire/common.py: runtime Unicode overrides for suits and __repr__ (temporary).
Testing Notes

Verified by running python -m solitaire:
Pyramid: stock flip/reset, king/13‑pair removes, Undo via button and U, Hint highlight with auto‑clear, unlimited stock shows ∞ only.
Klondike: options title renders correctly.
Follow‑Ups

Convert affected source files to UTF‑8 and replace mojibake at the source; remove temporary Unicode overrides in common.py.
Optional: animate hint highlight (pulse/fade) and/or standardize UI text rendering on DejaVu across scenes.
