### PR TITLE
Mouse Panning, Interactive Scrollbars, Responsive Klondike Layout, and Safer Window Sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,18 @@ ENV/
 # screenshots/
 # test_output/
 
+# User settings and saves (persisted outside repo or during local dev)
+# Windows APPDATA folder used by the game
+RandomRedMageSolitaire/
+# Home-directory dot folder used by the game (Linux/macOS)
+.random_red_mage_solitaire/
+# If a settings file is generated in the project during testing
+settings.json
+# Optional future save files/directories
+saves/
+*.sav
+*.save
+
 # -------------------------------------------------------------------
 # OS-specific junk
 # -------------------------------------------------------------------

--- a/src/solitaire/__main__.py
+++ b/src/solitaire/__main__.py
@@ -1,24 +1,53 @@
 
 # main.py - entry point
+import os
 import pygame
-from solitaire.common import (SCREEN_W, SCREEN_H, setup_fonts, TABLE_BG)
+from solitaire import common as C
 from solitaire.scenes.menu import MainMenuScene
 
+def _initial_window_size():
+    info = pygame.display.Info()
+    # Keep a safety margin so the window never hides under taskbar
+    margin_w, margin_h = 120, 140
+    w = min(C.SCREEN_W, max(640, info.current_w - margin_w))
+    h = min(C.SCREEN_H, max(480, info.current_h - margin_h))
+    return w, h
+
 def main():
+    # Center window and init
+    os.environ.setdefault("SDL_VIDEO_CENTERED", "1")
     pygame.init()
-    screen = pygame.display.set_mode((SCREEN_W, SCREEN_H))
+
+    # Pick a safe default size for this desktop
+    w, h = _initial_window_size()
+    C.SCREEN_W, C.SCREEN_H = w, h
+    screen = pygame.display.set_mode((w, h), pygame.RESIZABLE)
     pygame.display.set_caption("Solitaire Suite")
-    setup_fonts()
+    C.setup_fonts()
     clock = pygame.time.Clock()
     scene = MainMenuScene(app=None)
-    # Give scene a reference to an app container if needed; here we pass None
-    # but scenes don't currently use it beyond storage.
+
     running = True
     while running:
         dt = clock.tick(60) / 1000.0
         for e in pygame.event.get():
             if e.type == pygame.QUIT:
                 running = False
+            elif e.type == pygame.VIDEORESIZE:
+                # Apply new size and relayout UI
+                C.SCREEN_W, C.SCREEN_H = e.size
+                screen = pygame.display.set_mode((C.SCREEN_W, C.SCREEN_H), pygame.RESIZABLE)
+                # Relayout any scene that supports it
+                if hasattr(scene, "compute_layout"):
+                    try:
+                        scene.compute_layout()
+                    except Exception:
+                        pass
+                if hasattr(scene, "toolbar") and hasattr(scene.toolbar, "relayout"):
+                    try:
+                        scene.toolbar.relayout()
+                    except Exception:
+                        pass
             else:
                 scene.handle_event(e)
         if scene.next_scene is not None:

--- a/src/solitaire/scenes/menu.py
+++ b/src/solitaire/scenes/menu.py
@@ -10,6 +10,7 @@ class MainMenuScene(C.Scene):
         y  = 260
         self.b_klon = C.Button("Play Klondike", cx, y, center=True); y += 60
         self.b_pyr  = C.Button("Play Pyramid",  cx, y, center=True); y += 60
+        self.b_settings = C.Button("Settings", cx, y, center=True); y += 60
         self.b_quit = C.Button("Quit", cx, y, center=True)
 
 
@@ -22,6 +23,9 @@ class MainMenuScene(C.Scene):
             elif self.b_pyr.hovered((mx,my)):
                 from solitaire.modes.pyramid import PyramidOptionsScene
                 self.next_scene = PyramidOptionsScene(self.app)
+            elif self.b_settings.hovered((mx,my)):
+                from solitaire.scenes.settings import SettingsScene
+                self.next_scene = SettingsScene(self.app)
             elif self.b_quit.hovered((mx,my)):
                 pygame.quit(); raise SystemExit
         elif e.type == pygame.KEYDOWN:
@@ -33,5 +37,5 @@ class MainMenuScene(C.Scene):
         title = C.FONT_TITLE.render("Solitaire Suite", True, C.WHITE)
         screen.blit(title, (C.SCREEN_W//2 - title.get_width()//2, 120))
         mp = pygame.mouse.get_pos()
-        for b in [self.b_klon, self.b_pyr, self.b_quit]:
+        for b in [self.b_klon, self.b_pyr, self.b_settings, self.b_quit]:
             b.draw(screen, hover=b.hovered(mp))

--- a/src/solitaire/scenes/settings.py
+++ b/src/solitaire/scenes/settings.py
@@ -1,0 +1,248 @@
+import os
+import pygame
+from solitaire import common as C
+
+
+SIZES = ["Small", "Medium", "Large"]
+BACKS = [("Blue", 1), ("Blue", 2), ("Grey", 1), ("Grey", 2), ("Red", 1), ("Red", 2)]
+
+
+class SizeButton:
+    def __init__(self, label: str, w: int = 120, h: int = 42, selected: bool = False):
+        self.label = label
+        self.rect = pygame.Rect(0, 0, w, h)
+        self.selected = selected
+
+    def set_center(self, x: int, y: int):
+        self.rect.center = (x, y)
+
+    def hovered(self, pos) -> bool:
+        return self.rect.collidepoint(pos)
+
+    def draw(self, screen):
+        bg_sel = (190, 190, 205)  # darker when selected
+        bg = (230, 230, 235)
+        border = (160, 160, 170)
+        fill = bg_sel if self.selected else bg
+        pygame.draw.rect(screen, fill, self.rect, border_radius=10)
+        pygame.draw.rect(screen, border, self.rect, width=1, border_radius=10)
+        t = C.FONT_UI.render(self.label, True, (30, 30, 35))
+        screen.blit(t, (self.rect.centerx - t.get_width() // 2, self.rect.centery - t.get_height() // 2))
+
+
+class SettingsScene(C.Scene):
+    def __init__(self, app):
+        super().__init__(app)
+
+        # Load current settings
+        settings = C.get_current_settings()
+        size_name = settings.get("card_size", "Medium")
+        if size_name not in SIZES:
+            size_name = "Medium"
+
+        color = settings.get("back_color", "Blue")
+        variant = int(settings.get("back_variant", 1))
+        try:
+            back_idx = BACKS.index((color, variant))
+        except ValueError:
+            back_idx = 0
+
+        cx = C.SCREEN_W // 2
+        y = 160
+
+        self.title_text = "Settings"
+
+        # Size buttons (row above the preview). Medium button centered with the card.
+        self.size_selected = size_name
+        self.btn_small = SizeButton("Small", selected=(self.size_selected == "Small"))
+        self.btn_medium = SizeButton("Medium", selected=(self.size_selected == "Medium"))
+        self.btn_large = SizeButton("Large", selected=(self.size_selected == "Large"))
+
+        y += 140
+        self.preview_center = (cx, y)
+        # Static Y for size buttons computed to allow largest preview without overlap
+        max_h = self._size_to_wh("Large")[1]
+        btn_h = self.btn_medium.rect.height
+        top_margin = 16  # spacing between buttons and largest card top
+        self.buttons_row_y = self.preview_center[1] - (max_h // 2 + top_margin + btn_h // 2)
+        self.back_index = back_idx
+
+        # Arrows (positions updated each draw to align with card middle)
+        self.arrow_left = pygame.Rect(0, 0, 40, 40)
+        self.arrow_right = pygame.Rect(0, 0, 40, 40)
+
+        # Buttons (center group horizontally)
+        by = y + 170
+        bw = 200
+        gap = 16
+        total = bw * 2 + gap
+        left_x = cx - total // 2
+        self.b_save = C.Button("Save", left_x, by, w=bw, h=48, center=False)
+        self.b_back = C.Button("Back", left_x + bw + gap, by, w=bw, h=48, center=False)
+
+        # no flash message; we return to menu on Save
+
+    # Helpers
+    def _selected_size(self):
+        return self.size_selected
+
+    def _selected_back(self):
+        return BACKS[self.back_index]
+
+    def _change_back(self, delta):
+        self.back_index = (self.back_index + delta) % len(BACKS)
+
+    def _apply_and_save(self):
+        size_name = self._selected_size()
+        color, variant = self._selected_back()
+        C.save_settings({
+            "card_size": size_name,
+            "back_color": color,
+            "back_variant": int(variant),
+        })
+        # Apply runtime
+        C.apply_card_settings(size_name=size_name, back_color=color, back_variant=int(variant))
+        # After saving, return to main menu
+        from solitaire.scenes.menu import MainMenuScene
+        self.next_scene = MainMenuScene(self.app)
+
+    def handle_event(self, e):
+        # Update button and arrow layout before processing the click
+        self._update_layout_positions(self._selected_size())
+        if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
+            mx, my = e.pos
+            # Size buttons (exclusive selection)
+            if self.btn_small.hovered((mx, my)):
+                self._set_size("Small"); return
+            if self.btn_medium.hovered((mx, my)):
+                self._set_size("Medium"); return
+            if self.btn_large.hovered((mx, my)):
+                self._set_size("Large"); return
+            if self.arrow_left.collidepoint((mx, my)):
+                self._change_back(-1)
+                return
+            if self.arrow_right.collidepoint((mx, my)):
+                self._change_back(1)
+                return
+            if self.b_save.hovered((mx, my)):
+                self._apply_and_save()
+                return
+            if self.b_back.hovered((mx, my)):
+                from solitaire.scenes.menu import MainMenuScene
+                self.next_scene = MainMenuScene(self.app)
+                return
+        elif e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
+            from solitaire.scenes.menu import MainMenuScene
+            self.next_scene = MainMenuScene(self.app)
+
+    def update(self, dt):
+        pass
+
+    def _size_to_wh(self, size_name):
+        # Keep aspect ~5:7 like the gameplay
+        if size_name == "Small":
+            return 75, 105
+        if size_name == "Large":
+            return 150, 210
+        return 100, 140  # Medium default
+
+    def _set_size(self, size_name: str):
+        self.size_selected = size_name
+        self.btn_small.selected = (size_name == "Small")
+        self.btn_medium.selected = (size_name == "Medium")
+        self.btn_large.selected = (size_name == "Large")
+
+    def _preview_surface(self, size_name):
+        # Temporarily resolve path for preview without mutating global state
+        # Preview uses image assets if available; falls back to current back surface
+        w, h = self._size_to_wh(size_name)
+        color, variant = self._selected_back()
+        # Build path to the back image in the selected size
+        size_dir = {"Small": "Small", "Medium": "Medium", "Large": "Large"}[size_name]
+        base_dir = os.path.join(os.path.dirname(C.__file__), "assets", "cards", "PNG", size_dir)
+        fname = f"Back {color} {variant}.png"
+        path = os.path.join(base_dir, fname)
+        try:
+            if os.path.isfile(path):
+                s = pygame.image.load(path)
+                s = s.convert_alpha() if s.get_alpha() is not None else s.convert()
+                if s.get_size() != (w, h):
+                    s = pygame.transform.smoothscale(s, (w, h))
+                return s
+        except Exception:
+            pass
+        # Fallback: use current back renderer, scaled to requested size
+        s = C.get_back_surface()
+        if s.get_size() != (w, h):
+            s = pygame.transform.smoothscale(s, (w, h))
+        return s
+
+    def draw(self, screen):
+        screen.fill(C.TABLE_BG)
+
+        # Update dynamic layout positions for current size
+        self._update_layout_positions(self._selected_size())
+
+        # Title
+        title = C.FONT_TITLE.render(self.title_text, True, C.WHITE)
+        screen.blit(title, (C.SCREEN_W//2 - title.get_width()//2, 80))
+
+        # Size buttons row above preview; Medium centered with card
+        self.btn_small.draw(screen)
+        self.btn_medium.draw(screen)
+        self.btn_large.draw(screen)
+
+        # Preview
+        size_name = self._selected_size()
+        surf = self._preview_surface(size_name)
+        card_x = self.preview_center[0] - surf.get_width() // 2
+        card_y = self.preview_center[1] - surf.get_height() // 2
+        screen.blit(surf, (card_x, card_y))
+
+        # Arrow centers are set by _update_layout_positions; just use mid_y for drawing
+        mid_y = self.preview_center[1]
+        # Flip arrows to point away from the card (direction of navigation)
+        pygame.draw.polygon(screen, C.WHITE, [
+            (self.arrow_left.left, mid_y),
+            (self.arrow_left.left + 16, mid_y - 12),
+            (self.arrow_left.left + 16, mid_y + 12),
+        ])
+        pygame.draw.polygon(screen, C.WHITE, [
+            (self.arrow_right.right, mid_y),
+            (self.arrow_right.right - 16, mid_y - 12),
+            (self.arrow_right.right - 16, mid_y + 12),
+        ])
+
+        # Back caption
+        color, variant = self._selected_back()
+        cap = C.FONT_UI.render(f"Back: {color} {variant}", True, C.WHITE)
+        screen.blit(cap, (self.preview_center[0] - cap.get_width() // 2, card_y + surf.get_height() + 12))
+
+        # Buttons
+        mp = pygame.mouse.get_pos()
+        self.b_save.draw(screen, hover=self.b_save.hovered(mp))
+        self.b_back.draw(screen, hover=self.b_back.hovered(mp))
+
+        # no flash now; we immediately leave on Save
+
+    def _update_layout_positions(self, size_name: str):
+        # Compute positions for size buttons and arrows based on current preview size
+        w, h = self._size_to_wh(size_name)
+        card_x = self.preview_center[0] - w // 2
+        card_y = self.preview_center[1] - h // 2
+
+        # Size buttons use a static Y position; Medium centered with the card horizontally
+        row_y = self.buttons_row_y
+        btn_w = self.btn_medium.rect.width
+        spacing = 12
+        # Medium
+        self.btn_medium.set_center(self.preview_center[0], row_y)
+        # Small to the left; Large to the right with small space
+        self.btn_small.set_center(self.preview_center[0] - (btn_w + spacing), row_y)
+        self.btn_large.set_center(self.preview_center[0] + (btn_w + spacing), row_y)
+
+        # Arrows centered vertically to card
+        mid_y = self.preview_center[1]
+        gap = 18
+        self.arrow_left.center = (card_x - gap - self.arrow_left.width // 2, mid_y)
+        self.arrow_right.center = (card_x + w + gap + self.arrow_right.width // 2, mid_y)


### PR DESCRIPTION
Summary

Adds smooth mouse-based panning (wheel/trackpad + middle-drag) to Klondike and Pyramid.
Introduces interactive vertical and horizontal scrollbars (click-and-drag knob, click track to jump).
Updates Klondike layout to scale with card size to avoid pile/tableau collisions.
Ensures the window opens fully visible on different resolutions and is resizable.
Layers the top black bar above the playfield so content scrolls behind it; prevents clicks through the bar.
User-Facing

Wheel/trackpad: pans vertically; horizontal gestures pan horizontally.
Middle-mouse drag: pans both axes.
Scrollbars: draggable knobs; clicking track jumps to that position.
Top bar remains fixed; cards slide behind it while panning.
Klondike pile/tableau positions adapt to card size; no overlaps after resizing.
Key Changes

src/solitaire/common.py

Added DRAW_OFFSET_X (existing DRAW_OFFSET_Y) for 2D panning.
Updated Pile.draw(...) to offset blits by DRAW_OFFSET_X/Y.
Added TOP_BAR_H = 60 used to size/position overlays and block clicks under the bar.
src/solitaire/__main__.py

Window is now RESIZABLE and centered.
Chooses a safe initial size based on desktop (pygame.display.Info()), leaving margins to avoid taskbar overlap.
On VIDEORESIZE, updates C.SCREEN_W/H, resets display, calls scene.compute_layout() (if present) and toolbar.relayout().
src/solitaire/modes/klondike.py

New compute_layout() recalculates foundations/stock/waste/tableau using CARD_W/H, CARD_GAP_X/Y, and scaled fan_y to avoid collisions.
Added scroll_x, 2D panning (wheel and middle-drag), and clamp logic based on content bounds.
Interactive scrollbars: _vertical_scrollbar() and _horizontal_scrollbar() compute track/knob geometry; event handlers support knob drag and track click-to-jump.
Hit-tests use world coordinates (mxw, myw) so dragging and clicks work while panned.
Blocks clicks under the top bar; draws top bar and toolbar last so content scrolls behind.
src/solitaire/modes/pyramid.py

Added scroll_x, 2D panning (wheel and middle-drag), and clamps.
Switched pyramid/pile drawing to use DRAW_OFFSET_X/Y.
Interactive scrollbars and event handlers (drag knob, click track).
Blocks clicks under the top bar; draws top bar and toolbar last for proper layering.
Why

Large cards can exceed the viewport; panning + scrollbars make the whole play area accessible.
Klondike placement previously collided as card sizes changed; layout now scales responsively.
Window no longer hides beneath the Windows taskbar and adapts to different displays.
Testing Notes

Resize the window: layout reflows; toolbar stays aligned; scrollbars adjust.
Wheel/trackpad scroll: verify vertical and horizontal panning works.
Middle-drag: pans both axes; release stops panning.
Scrollbars: drag knobs, click tracks to jump; both axes when content exceeds view.
Clicks under the top bar are ignored; content appears behind the bar.
Klondike: switch card sizes (via settings), start a new Klondike game — verify foundations/stock/waste/tableau don’t collide.
Drag/move/undo still behave correctly when panned.
Implementation Details

Piles rely on DRAW_OFFSET_X/Y during draw(), leaving game state coordinates unchanged; event processing subtracts offsets to hit-test.
Scrollbar math maps knob position to scroll ranges with bounds derived from content extents plus a small margin.
TOP_BAR_H provides a single source of truth for overlay height and click blocking.
Backward Compatibility

Other scenes that don’t use panning remain unaffected.
Pile.draw offsetting is backward compatible as offsets default to 0.
Follow‑ups (optional)

Add hover/pressed styling to scrollbars.
Add “Fit to Desktop” and fullscreen toggles.
Persist window size and last scroll positions.
Apply tighter compute-layout to Pyramid (like Klondike).
Optional kinetic scrolling for trackpads.