### PR TITLE
Add FreeCell mode, delayed “peek on hover”, and docs polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Solitaire Suite (Pygame)
 
 Overview
-- Simple Pygame-based solitaire suite including Klondike and Pyramid.
+- Simple Pygame-based solitaire suite including Klondike, FreeCell, and Pyramid.
 - Uses built-in vector drawing with optional image card assets bundled under `src/solitaire/assets`.
 
 Requirements
@@ -36,25 +36,64 @@ Controls
   - `U`: Undo last move
   - `A`: Auto-finish when available
 
+- FreeCell:
+  - Drag single cards or valid descending, alternating sequences between tableau columns
+  - Place one card per free cell (top-left)
+  - Build foundations by suit from Ace upward (top-right)
+  - `N`: New deal
+  - `R`: Restart current deal
+  - `U`: Undo last move
+  - `A`: Auto-move available cards to foundations
+
 - Pyramid:
   - Click the stock to flip to waste
   - Remove any exposed King, or any two exposed cards summing to 13
   - Limited stock resets based on options
 
 Settings
-- Card assets and style are configured in `src/solitaire/common.py`:
-  - `USE_IMAGE_CARDS`: use PNG assets if available; falls back to drawn cards
-  - `BACK_COLOR` and `BACK_VARIANT`: choose the card back style
-  - `IMAGE_CARDS_DIR`: path to preferred card face size (`PNG/Medium` by default)
+- Use the in‑game Settings screen (from the main menu) to choose:
+  - Card size: Small | Medium | Large
+  - Card back: Blue/Grey/Red + variant
+- Choices are saved to disk and applied at runtime:
+  - Windows: `%APPDATA%/RandomRedMageSolitaire/settings.json`
+  - macOS/Linux: `~/.random_red_mage_solitaire/settings.json`
+- Rendering notes:
+  - PNG image cards are used by default if available and are scaled to the selected size.
+  - Falls back to vector‑drawn cards when images are unavailable.
 
 Project Layout
 - `src/solitaire/__main__.py`: entry point
 - `src/solitaire/scenes/menu.py`: main menu
 - `src/solitaire/modes/klondike.py`: Klondike options and game scenes
+- `src/solitaire/modes/freecell.py`: FreeCell options and game scenes
 - `src/solitaire/modes/pyramid.py`: Pyramid options and game scenes
 - `src/solitaire/ui.py`: shared UI widgets (toolbar, buttons)
 
 Notes
 - Unicode cleanup: suit symbols now render as standard `♠ ♥ ♦ ♣`. If your system font misses them, image cards are used by default.
 - Assets include card PNGs and a font license; see `src/solitaire/assets/` for details.
+ - Hover Peek: in Klondike and FreeCell, hovering a partially covered, face‑up card reveals it in place after ~2 seconds so suits/ranks are readable. Move/scroll/click to cancel.
 
+Contributing
+- Dev setup:
+  - Python 3.11+, `python -m pip install -e .` in the repo root
+  - Run with `python -m solitaire` (ensure `PYTHONPATH` includes `src` if not installed)
+- Code style:
+  - Keep changes small and focused; match existing patterns and naming
+  - Prefer adding a new mode under `src/solitaire/modes/<name>.py` with:
+    - `<Name>OptionsScene` and `<Name>GameScene`
+    - Toolbar via `solitaire.ui.make_toolbar`
+    - Use shared primitives from `solitaire.common` (`Card`, `Pile`, `UndoManager`)
+  - UI should respect window resizing and current card size from settings
+- Manual QA checklist:
+  - Resize window; verify layout recomputes
+  - Start each mode; basic play loop works; Undo/Restart/New behave
+  - Settings changes (size/back) persist and take effect without restart
+  - Image cards load; fallback drawing looks acceptable
+
+Known Issues / Future Work
+- FreeCell: scrollbar is wheel/trackpad only; knob is not draggable yet
+- FreeCell: cannot move cards back out of foundations (some variants allow this)
+- Klondike/FreeCell: peek delay is fixed at ~2s; consider a settings toggle for delay/disable
+- Asset loading does per‑size scaling on first use; initial draw may incur a brief cost
+- Pyramid intentionally has no peek overlay (not needed for its mechanics)

--- a/src/solitaire/common.py
+++ b/src/solitaire/common.py
@@ -431,19 +431,7 @@ class UndoManager:
             fn = self._stack.pop()
             fn()
 
-# --- Text cleanup overrides ---
-# Ensure suit symbols render with Unicode glyphs, and clean __repr__ text
-SUITS = ["♠", "♥", "♦", "♣"]  # 0..3
-
-def _card_repr(self):
-    return f"{RANK_TO_TEXT[self.rank]}{SUITS[self.suit]}{'↑' if self.face_up else '↓'}"
-
-Card.__repr__ = _card_repr
-
-# Canonical Unicode values (append to ensure clean runtime values)
-SUITS = ["\u2660", "\u2665", "\u2666", "\u2663"]  # ["♠", "♥", "♦", "♣"]
-
-def _card_repr_unicode(self):
-    return f"{RANK_TO_TEXT[self.rank]}{SUITS[self.suit]}{'↑' if self.face_up else '↓'}"
-
-Card.__repr__ = _card_repr_unicode
+"""
+Note: SUITS and Card.__repr__ are defined once above.
+Avoid redefining these at the bottom to prevent confusion.
+"""

--- a/src/solitaire/modes/freecell.py
+++ b/src/solitaire/modes/freecell.py
@@ -1,0 +1,507 @@
+# freecell.py - FreeCell mode (options + game)
+import pygame
+from typing import List, Optional, Tuple
+from solitaire import common as C
+from solitaire.ui import make_toolbar, DEFAULT_BUTTON_HEIGHT
+
+
+def is_red(suit: int) -> bool:
+    return suit in (1, 2)
+
+
+class FreeCellOptionsScene(C.Scene):
+    def __init__(self, app):
+        super().__init__(app)
+        cx = C.SCREEN_W // 2 - 210
+        y = 300
+        # Use width 420 to center like other option screens
+        self.b_start = C.Button("Start FreeCell", cx, y, w=420); y += 70
+        self.b_back = C.Button("Back", cx, y, w=420)
+
+    def handle_event(self, e):
+        if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
+            mx, my = e.pos
+            if self.b_start.hovered((mx, my)):
+                self.next_scene = FreeCellGameScene(self.app)
+            elif self.b_back.hovered((mx, my)):
+                from solitaire.scenes.menu import MainMenuScene
+                self.next_scene = MainMenuScene(self.app)
+        elif e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
+            from solitaire.scenes.menu import MainMenuScene
+            self.next_scene = MainMenuScene(self.app)
+
+    def draw(self, screen):
+        screen.fill(C.TABLE_BG)
+        title = C.FONT_TITLE.render("FreeCell - Options", True, C.WHITE)
+        screen.blit(title, (C.SCREEN_W // 2 - title.get_width() // 2, 140))
+        mp = pygame.mouse.get_pos()
+        for b in [self.b_start, self.b_back]:
+            b.draw(screen, hover=b.hovered(mp))
+
+
+class FreeCellGameScene(C.Scene):
+    def __init__(self, app):
+        super().__init__(app)
+
+        # Scrolling (vertical; FreeCell can build tall columns)
+        self.scroll_y = 0
+        self._drag_vscroll = False
+
+        # Piles
+        self.freecells: List[C.Pile] = [C.Pile(0, 0) for _ in range(4)]
+        self.foundations: List[C.Pile] = [C.Pile(0, 0) for _ in range(4)]
+        self.tableau: List[C.Pile] = [C.Pile(0, 0, fan_y=max(24, C.CARD_H // 5)) for _ in range(8)]
+
+        # Drag state: (stack, src_kind, src_index)
+        self.drag_stack: Optional[Tuple[List[C.Card], str, int]] = None
+        self.drag_offset = (0, 0)
+        self.peek_overlay: Optional[Tuple[C.Card, int, int]] = None  # (card, world_x, world_y)
+        self._peek_candidate: Optional[Tuple[int, int]] = None       # (pile_id, index)
+        self._peek_started_at: int = 0
+        self._peek_pending: Optional[Tuple[C.Card, int, int]] = None
+
+        # Undo manager
+        self.undo_mgr = C.UndoManager()
+
+        # Toolbar
+        def goto_menu():
+            from solitaire.scenes.menu import MainMenuScene
+            self.next_scene = MainMenuScene(self.app)
+
+        def can_undo():
+            return self.undo_mgr.can_undo()
+
+        actions = {
+            "Menu":    {"on_click": goto_menu},
+            "New":     {"on_click": self.deal_new},
+            "Restart": {"on_click": self.restart, "tooltip": "Restart current deal"},
+            "Undo":    {"on_click": self.undo, "enabled": can_undo, "tooltip": "Undo last move"},
+            "Auto":    {"on_click": self.auto_to_foundations, "tooltip": "Auto-move available cards to foundations"},
+        }
+        self.toolbar = make_toolbar(
+            actions,
+            height=DEFAULT_BUTTON_HEIGHT,
+            margin=(10, 8),
+            gap=8,
+            align="right",
+            width_provider=lambda: C.SCREEN_W,
+        )
+
+        self.message = ""
+        self.compute_layout()
+        self.deal_new()
+
+    # ----- Layout -----
+    def compute_layout(self):
+        gap_x = getattr(C, "CARD_GAP_X", max(18, C.CARD_W // 6))
+        # Leave generous space below the top bar so labels and card tops don't overlap it
+        top_bar_h = getattr(C, "TOP_BAR_H", 60)
+        top_y = max(100, top_bar_h + 40)
+
+        # Extra separation between FreeCells group (left) and Foundations group (right)
+        group_gap = max(int(C.CARD_W * 0.8), 60)
+
+        # Top row: 4 free cells (left), 4 foundations (right) with extra group gap
+        total_w = 8 * C.CARD_W + 7 * gap_x + group_gap
+        left_x = (C.SCREEN_W - total_w) // 2
+        # Freecells
+        for i in range(4):
+            x = left_x + i * (C.CARD_W + gap_x)
+            self.freecells[i].x, self.freecells[i].y = x, top_y
+        # Foundations
+        for i in range(4):
+            x = left_x + 4 * (C.CARD_W + gap_x) + group_gap + i * (C.CARD_W + gap_x)
+            self.foundations[i].x, self.foundations[i].y = x, top_y
+
+        # Tableau under top row
+        base_y = top_y + C.CARD_H + getattr(C, "CARD_GAP_Y", 26)
+        for i in range(8):
+            x = left_x + i * (C.CARD_W + gap_x)
+            self.tableau[i].x, self.tableau[i].y = x, base_y
+
+    # ----- Deal / Restart -----
+    def _clear(self):
+        for p in self.tableau:
+            p.cards.clear()
+        for p in self.freecells:
+            p.cards.clear()
+        for p in self.foundations:
+            p.cards.clear()
+        self.drag_stack = None
+        self.message = ""
+
+    def deal_new(self):
+        self._clear()
+        deck = C.make_deck(shuffle=True)
+        # Remember initial order for restart
+        self._initial_order = [(c.suit, c.rank) for c in deck]
+        for idx, c in enumerate(deck):
+            c.face_up = True
+            col = idx % 8
+            self.tableau[col].cards.append(c)
+        # reset undo
+        self.undo_mgr = C.UndoManager()
+        self.push_undo()
+
+    def restart(self):
+        if getattr(self, "_initial_order", None):
+            deck = [C.Card(s, r, True) for (s, r) in self._initial_order]
+            self._clear()
+            for idx, c in enumerate(deck):
+                col = idx % 8
+                self.tableau[col].cards.append(c)
+            self.undo_mgr = C.UndoManager()
+            self.push_undo()
+
+    # ----- Undo -----
+    def record_snapshot(self):
+        return {
+            "freecells": [[(c.suit, c.rank, c.face_up) for c in p.cards] for p in self.freecells],
+            "foundations": [[(c.suit, c.rank, c.face_up) for c in p.cards] for p in self.foundations],
+            "tableau": [[(c.suit, c.rank, c.face_up) for c in p.cards] for p in self.tableau],
+            "message": self.message,
+            "scroll_y": self.scroll_y,
+        }
+
+    def restore_snapshot(self, snap):
+        def mk(seq):
+            return [C.Card(s, r, f) for (s, r, f) in seq]
+        for i, p in enumerate(self.freecells):
+            p.cards = mk(snap["freecells"][i])
+        for i, p in enumerate(self.foundations):
+            p.cards = mk(snap["foundations"][i])
+        for i, p in enumerate(self.tableau):
+            p.cards = mk(snap["tableau"][i])
+        self.message = snap.get("message", "")
+        self.scroll_y = snap.get("scroll_y", 0)
+
+    def push_undo(self):
+        s = self.record_snapshot()
+        self.undo_mgr.push(lambda snap=s: self.restore_snapshot(snap))
+
+    def undo(self):
+        if self.undo_mgr.can_undo():
+            self.undo_mgr.undo()
+
+    # ----- Rules -----
+    def _can_stack_tableau(self, upper: C.Card, lower: Optional[C.Card]) -> bool:
+        if lower is None:
+            return True  # empty target column accepts any rank in FreeCell
+        # Alternating colors, descending by 1
+        return (is_red(upper.suit) != is_red(lower.suit)) and (upper.rank == lower.rank - 1)
+
+    def _can_move_to_foundation(self, card: C.Card, fi: int) -> bool:
+        f = self.foundations[fi]
+        if not f.cards:
+            return card.rank == 1  # Ace
+        top = f.cards[-1]
+        return (card.suit == top.suit) and (card.rank == top.rank + 1)
+
+    def _is_valid_sequence(self, seq: List[C.Card]) -> bool:
+        # Strictly descending by 1, alternating colors
+        for i in range(len(seq) - 1):
+            a, b = seq[i], seq[i + 1]
+            if not (is_red(a.suit) != is_red(b.suit) and a.rank == b.rank + 1):
+                return False
+        return True
+
+    def _max_movable(self, target_is_empty: bool) -> int:
+        empty_cells = sum(1 for p in self.freecells if not p.cards)
+        empty_cols = sum(1 for p in self.tableau if not p.cards)
+        if target_is_empty and empty_cols > 0:
+            empty_cols -= 1  # destination empty column is not a helper
+        # (empty_cells + 1) * 2^(empty_cols)
+        cap = (empty_cells + 1)
+        # Avoid huge growth; practical boards keep this small
+        for _ in range(empty_cols):
+            cap *= 2
+            if cap > 52:
+                return 52
+        return max(1, cap)
+
+    # ----- Auto to foundation -----
+    def auto_to_foundations(self):
+        moved_any = False
+        while True:
+            moved = False
+            # Try freecells first
+            for fi in range(4):
+                for ci in range(4):
+                    if self.freecells[ci].cards:
+                        c = self.freecells[ci].cards[-1]
+                        if self._can_move_to_foundation(c, fi):
+                            self.push_undo()
+                            self.freecells[ci].cards.pop()
+                            self.foundations[fi].cards.append(c)
+                            moved = True
+                            moved_any = True
+                            break
+                if moved:
+                    break
+            if moved:
+                continue
+            # Try tableau tops
+            for fi in range(4):
+                for ti in range(8):
+                    if self.tableau[ti].cards:
+                        c = self.tableau[ti].cards[-1]
+                        if self._can_move_to_foundation(c, fi):
+                            self.push_undo()
+                            self.tableau[ti].cards.pop()
+                            self.foundations[fi].cards.append(c)
+                            moved = True
+                            moved_any = True
+                            break
+                if moved:
+                    break
+            if not moved:
+                break
+        if moved_any:
+            # Expand any newly uncovered card faces (should already be face up)
+            pass
+
+    # ----- Events -----
+    def handle_event(self, e):
+        if self.toolbar.handle_event(e):
+            return
+
+        if e.type == pygame.MOUSEWHEEL:
+            self.scroll_y += e.y * 60
+            self._clamp_scroll()
+            # Scrolling cancels peek
+            self.peek_overlay = None
+            self._peek_candidate = None
+            return
+
+        if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
+            mx, my = e.pos
+            myw = my - self.scroll_y
+            # Clicking cancels peek
+            self.peek_overlay = None
+            self._peek_candidate = None
+
+            # Start drag from freecell
+            for i, p in enumerate(self.freecells):
+                if p.top_rect().collidepoint((mx, myw)) and p.cards:
+                    c = p.cards.pop()
+                    self.drag_stack = ([c], "free", i)
+                    self.drag_offset = (mx - p.top_rect().x, myw - p.top_rect().y)
+                    return
+
+            # Start drag from tableau (allow valid sequences)
+            for i, p in enumerate(self.tableau):
+                if not p.cards:
+                    continue
+                # Find clicked index (within tableau pile considering fan)
+                idx = p.hit((mx, myw))
+                if idx is None:
+                    continue
+                if idx == -1 and p.cards:
+                    idx = len(p.cards) - 1
+                seq = p.cards[idx:]
+                if self._is_valid_sequence(seq):
+                    chosen_idx = idx
+                    picked = seq[:]
+                else:
+                    chosen_idx = len(p.cards) - 1
+                    picked = [p.cards[-1]]
+                # Remove picked cards from the column immediately (like Klondike)
+                p.cards = p.cards[:chosen_idx]
+                self.drag_stack = (picked, "tab", i)
+                top_r = p.rect_for_index(chosen_idx)
+                self.drag_offset = (mx - top_r.x, myw - top_r.y)
+                return
+
+            # Start drag from foundation? (disallow moving out to keep rules simple)
+
+        if e.type == pygame.MOUSEBUTTONUP and e.button == 1:
+            if not self.drag_stack:
+                return
+            stack, skind, sidx = self.drag_stack
+            self.drag_stack = None
+
+            mx, my = e.pos
+            myw = my - self.scroll_y
+
+            # Try drop on foundations (only single card)
+            if len(stack) == 1:
+                for fi, f in enumerate(self.foundations):
+                    if f.top_rect().collidepoint((mx, myw)) and self._can_move_to_foundation(stack[0], fi):
+                        self.push_undo()
+                        f.cards.append(stack[0])
+                        return
+
+            # Try drop on freecells (only single card)
+            if len(stack) == 1:
+                for ci, cell in enumerate(self.freecells):
+                    if cell.top_rect().collidepoint((mx, myw)) and not cell.cards:
+                        self.push_undo()
+                        cell.cards.append(stack[0])
+                        return
+
+            # Try drop on tableau
+            for ti, t in enumerate(self.tableau):
+                if t.top_rect().collidepoint((mx, myw)):
+                    target_top = t.cards[-1] if t.cards else None
+                    if self._can_stack_tableau(stack[0], target_top):
+                        # Capacity check for sequences
+                        cap = self._max_movable(target_is_empty=(len(t.cards) == 0))
+                        if len(stack) <= cap:
+                            self.push_undo()
+                            t.cards.extend(stack)
+                            return
+
+            # If we reach here, drop failed: restore to origin
+            if skind == "free":
+                self.freecells[sidx].cards.extend(stack)
+            elif skind == "tab":
+                self.tableau[sidx].cards.extend(stack)
+            return
+
+        if e.type == pygame.MOUSEMOTION and not self.drag_stack:
+            # Compute peek overlay for face-up card under cursor in tableau
+            mx, my = e.pos
+            myw = my - self.scroll_y
+            self.peek_overlay = None
+            candidate = None
+            pending = None
+            for p in self.tableau:
+                hi = p.hit((mx, myw))
+                if hi is None or hi == -1:
+                    continue
+                # Only peek if the card is not already fully exposed (not the top card)
+                if hi < len(p.cards) - 1 and p.cards[hi].face_up:
+                    r = p.rect_for_index(hi)
+                    candidate = (id(p), hi)
+                    pending = (p.cards[hi], r.x, r.y)
+                    break
+
+            now = pygame.time.get_ticks()
+            if candidate is None:
+                self._peek_candidate = None
+                self._peek_pending = None
+                return
+            if candidate != self._peek_candidate:
+                self._peek_candidate = candidate
+                self._peek_started_at = now
+                self._peek_pending = pending
+                return
+            # Same candidate; check delay
+            if now - self._peek_started_at >= 2000 and self._peek_pending is not None:
+                self.peek_overlay = self._peek_pending
+
+        if e.type == pygame.KEYDOWN:
+            if e.key == pygame.K_r:
+                self.restart()
+            elif e.key == pygame.K_n:
+                self.deal_new()
+            elif e.key == pygame.K_u:
+                self.undo()
+            elif e.key == pygame.K_a:
+                self.auto_to_foundations()
+            elif e.key == pygame.K_ESCAPE:
+                from solitaire.scenes.menu import MainMenuScene
+                self.next_scene = MainMenuScene(self.app)
+
+    # ----- Scroll helpers -----
+    def _content_bottom_y(self) -> int:
+        bottoms = []
+        # Consider tallest tableau column
+        for p in self.tableau:
+            if p.cards:
+                r = p.rect_for_index(len(p.cards) - 1)
+                bottoms.append(r.bottom)
+            else:
+                bottoms.append(p.y + C.CARD_H)
+        return max(bottoms) if bottoms else C.SCREEN_H
+
+    def _clamp_scroll(self):
+        bottom = self._content_bottom_y()
+        min_scroll = min(0, C.SCREEN_H - bottom - 20)
+        if self.scroll_y > 0:
+            self.scroll_y = 0
+        if self.scroll_y < min_scroll:
+            self.scroll_y = min_scroll
+
+    def _vertical_scrollbar(self):
+        bottom = self._content_bottom_y()
+        if bottom <= C.SCREEN_H:
+            return None
+        track_x = C.SCREEN_W - 12
+        track_y = getattr(C, "TOP_BAR_H", 60)
+        track_h = C.SCREEN_H - track_y - 10
+        track_rect = pygame.Rect(track_x, track_y, 6, track_h)
+        view_h = C.SCREEN_H
+        content_h = bottom
+        knob_h = max(30, int(track_h * (view_h / content_h)))
+        max_scroll = 0
+        min_scroll = C.SCREEN_H - bottom - 20
+        denom = (max_scroll - min_scroll)
+        t = (self.scroll_y - min_scroll) / denom if denom != 0 else 1.0
+        knob_y = int(track_y + (track_h - knob_h) * (1.0 - t))
+        knob_rect = pygame.Rect(track_x, knob_y, 6, knob_h)
+        return track_rect, knob_rect, min_scroll, max_scroll, track_y, track_h, knob_h
+
+    # ----- Drawing -----
+    def draw(self, screen):
+        screen.fill(C.TABLE_BG)
+
+        # Apply scroll for card content
+        C.DRAW_OFFSET_X = 0
+        C.DRAW_OFFSET_Y = self.scroll_y
+
+        # If a peek is pending and delay elapsed, activate it even without mouse movement
+        now = pygame.time.get_ticks()
+        if (
+            self.peek_overlay is None
+            and self._peek_candidate is not None
+            and self._peek_pending is not None
+            and now - self._peek_started_at >= 2000
+        ):
+            self.peek_overlay = self._peek_pending
+
+        # Draw top placeholders
+        font_lbl = C.FONT_SMALL
+        for i, p in enumerate(self.freecells):
+            p.draw(screen)
+            lab = font_lbl.render("Free", True, (245, 245, 245))
+            screen.blit(lab, (p.x + (C.CARD_W - lab.get_width()) // 2, p.y - 22 + self.scroll_y))
+        for i, p in enumerate(self.foundations):
+            p.draw(screen)
+            lab = font_lbl.render("Foundation", True, (245, 245, 245))
+            screen.blit(lab, (p.x + (C.CARD_W - lab.get_width()) // 2, p.y - 22 + self.scroll_y))
+
+        # Draw tableau
+        for p in self.tableau:
+            p.draw(screen)
+
+        # Draw dragging stack on top
+        if self.drag_stack:
+            stack, _, _ = self.drag_stack
+            mx, my = pygame.mouse.get_pos()
+            # Render as a fanned stack following the mouse
+            for i, c in enumerate(stack):
+                surf = C.get_card_surface(c)
+                screen.blit(surf, (mx - C.CARD_W // 2, my - C.CARD_H // 2 + i * max(24, C.CARD_H // 5)))
+        elif self.peek_overlay:
+            # Show a full preview of the hovered face-up, partially covered card, in-place
+            card, rx, ry = self.peek_overlay
+            surf = C.get_card_surface(card)
+            sx = rx
+            sy = ry + self.scroll_y
+            screen.blit(surf, (sx, sy))
+
+        # Reset offsets for UI drawing
+        C.DRAW_OFFSET_X = 0
+        C.DRAW_OFFSET_Y = 0
+
+        # Scrollbar
+        vsb = self._vertical_scrollbar()
+        if vsb is not None:
+            track_rect, knob_rect, *_ = vsb
+            pygame.draw.rect(screen, (40, 40, 40), track_rect, border_radius=3)
+            pygame.draw.rect(screen, (200, 200, 200), knob_rect, border_radius=3)
+
+        # Title bar and toolbar
+        C.Scene.draw_top_bar(self, screen, "FreeCell")
+        self.toolbar.draw(screen)

--- a/src/solitaire/scenes/menu.py
+++ b/src/solitaire/scenes/menu.py
@@ -9,6 +9,7 @@ class MainMenuScene(C.Scene):
         cx = C.SCREEN_W // 2
         y  = 260
         self.b_klon = C.Button("Play Klondike", cx, y, center=True); y += 60
+        self.b_free = C.Button("Play FreeCell", cx, y, center=True); y += 60
         self.b_pyr  = C.Button("Play Pyramid",  cx, y, center=True); y += 60
         self.b_settings = C.Button("Settings", cx, y, center=True); y += 60
         self.b_quit = C.Button("Quit", cx, y, center=True)
@@ -20,6 +21,9 @@ class MainMenuScene(C.Scene):
             if self.b_klon.hovered((mx,my)):
                 from solitaire.modes.klondike import KlondikeOptionsScene
                 self.next_scene = KlondikeOptionsScene(self.app)
+            elif self.b_free.hovered((mx,my)):
+                from solitaire.modes.freecell import FreeCellOptionsScene
+                self.next_scene = FreeCellOptionsScene(self.app)
             elif self.b_pyr.hovered((mx,my)):
                 from solitaire.modes.pyramid import PyramidOptionsScene
                 self.next_scene = PyramidOptionsScene(self.app)
@@ -37,5 +41,5 @@ class MainMenuScene(C.Scene):
         title = C.FONT_TITLE.render("Solitaire Suite", True, C.WHITE)
         screen.blit(title, (C.SCREEN_W//2 - title.get_width()//2, 120))
         mp = pygame.mouse.get_pos()
-        for b in [self.b_klon, self.b_pyr, self.b_settings, self.b_quit]:
+        for b in [self.b_klon, self.b_free, self.b_pyr, self.b_settings, self.b_quit]:
             b.draw(screen, hover=b.hovered(mp))


### PR DESCRIPTION
Add FreeCell mode, delayed “peek on hover”, and docs polish

Summary

New FreeCell mode (options + gameplay with undo/auto).
2s delayed “peek on hover” for covered face-up cards in Klondike/FreeCell.
UI/layout polish for FreeCell options and top row spacing.
Fix FreeCell drag ghosting by removing cards at drag start.
Remove duplicate SUITS/repr definitions.
Update README (FreeCell, Settings UX, Contributing, Known Issues).
Motivation

Expand the suite with a popular variant (FreeCell).
Improve readability of covered cards without extra clicks.
Tidy code and documentation ahead of future modes.
Key Changes

New: src/solitaire/modes/freecell.py
Menu: src/solitaire/scenes/menu.py adds “Play FreeCell”
Peek: src/solitaire/modes/klondike.py, src/solitaire/modes/freecell.py
Cleanup: src/solitaire/common.py
Docs: README.md
UX Notes

FreeCell options use centered 420px buttons.
Free cells and foundations spaced apart; row sits below top bar.
Peek appears in-place after ~2 seconds; no highlight; cancels on move/scroll/click.
FreeCell drag now removes source card(s) immediately; restores on failed drop.
Technical Details

FreeCell deal: all face-up, dealt round-robin to 8 columns.
Sequence capacity: (empty_freecells + 1) * 2^(empty_tableau_columns) (destination empty col excluded).
Peek uses per-card timers; activation also checked during draw loop.
Testing Checklist

Global:
Resize window; verify layouts update.
Settings: change size/back; verify persistence and runtime update.
Klondike:
Hover a covered face-up card for ~2s → peek appears; moving/clicking/scrolling cancels.
Normal play unaffected.
FreeCell:
Drag single cards and valid sequences; invalid drops restore to origin.
Place in free cells; build foundations from Ace upward.
Auto moves eligible tops to foundations.
Hover a covered face-up card for ~2s → peek appears; cancels on interaction.
Pyramid:
Unchanged behavior.
Known Issues / Follow-ups

FreeCell: scrollbar knob not draggable (wheel/trackpad supported).
FreeCell: cannot move cards back out of foundations (some variants allow this).
Peek delay fixed at ~2s; consider Settings toggle to adjust/disable.
First-use image scaling may cause a brief frame cost.