### PR TITLE
Adding Packaging Options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build Solitaire Suite
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-windows:
+    name: Windows (PyInstaller onedir)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pyinstaller
+
+      - name: Package (PyInstaller)
+        shell: pwsh
+        run: ./scripts/package_windows_pyinstaller.ps1
+
+      - name: Upload artifact (Windows)
+        uses: actions/upload-artifact@v4
+        with:
+          name: SolitaireSuite-windows
+          path: dist/SolitaireSuite/**
+
+  build-macos:
+    name: macOS (PyInstaller onedir)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e . pyinstaller
+
+      - name: Make packaging script executable
+        run: chmod +x scripts/package_macos_pyinstaller.sh
+
+      - name: Package (PyInstaller)
+        run: bash scripts/package_macos_pyinstaller.sh
+
+      - name: Upload artifact (macOS)
+        uses: actions/upload-artifact@v4
+        with:
+          name: SolitaireSuite-macos
+          path: dist/SolitaireSuite/**
+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Project Layout
 - `src/solitaire/modes/freecell.py`: FreeCell options and game scenes
 - `src/solitaire/modes/pyramid.py`: Pyramid options and game scenes
 - `src/solitaire/ui.py`: shared UI widgets (toolbar, buttons)
+ - `packaging/pyinstaller/solitaire.spec`: PyInstaller build spec
+ - `scripts/package_windows_pyinstaller.ps1`: Windows packaging helper
+ - `scripts/package_macos_pyinstaller.sh`: macOS packaging helper
 
 Notes
 - Unicode cleanup: suit symbols now render as standard `♠ ♥ ♦ ♣`. If your system font misses them, image cards are used by default.
@@ -97,3 +100,13 @@ Known Issues / Future Work
 - Klondike/FreeCell: peek delay is fixed at ~2s; consider a settings toggle for delay/disable
 - Asset loading does per‑size scaling on first use; initial draw may incur a brief cost
 - Pyramid intentionally has no peek overlay (not needed for its mechanics)
+
+Packaging
+- PyInstaller (recommended for quick, cross‑platform bundles):
+  - Windows (PowerShell): `./scripts/package_windows_pyinstaller.ps1`
+  - macOS (Terminal): `bash ./scripts/package_macos_pyinstaller.sh`
+  - Outputs to `dist/SolitaireSuite` (onedir). One‑file builds are supported by toggling the script flag but start slower.
+- Notes:
+  - Assets (`src/solitaire/assets`) are bundled via the spec. If you add new files, they will be included automatically.
+  - Pygame DLLs/frameworks are handled by PyInstaller hooks; no extra steps usually needed.
+  - To set a custom icon, edit `packaging/pyinstaller/solitaire.spec` and set `icon` to a `.ico` (Windows) or `.icns` (macOS) path.

--- a/packaging/pyinstaller/solitaire.spec
+++ b/packaging/pyinstaller/solitaire.spec
@@ -1,0 +1,71 @@
+# PyInstaller spec for Solitaire Suite (Windows/macOS)
+# Produces a windowed, onedir app with bundled assets.
+
+import os, sys
+from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.building.build_main import Analysis, PYZ, EXE, COLLECT
+from PyInstaller.building.datastruct import Tree
+
+# Resolve repo root relative to this spec file; fall back to sys.argv[0] when __file__ is not set
+try:
+    _spec_dir = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    _spec_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+here = os.path.abspath(os.path.join(_spec_dir, '..', '..'))
+entry = os.path.join(here, 'src', 'solitaire', '__main__.py')
+
+# Bundle asset tree under the same relative path inside the app
+assets_dir = os.path.join(here, 'src', 'solitaire', 'assets')
+assets_tree = []
+if os.path.isdir(assets_dir):
+    # Prefix to keep package-like path for runtime lookups
+    assets_tree = [Tree(assets_dir, prefix=os.path.join('solitaire', 'assets'))]
+
+# Pygame can use hidden imports depending on platform; collect just in case
+hidden = collect_submodules('pygame')
+
+a = Analysis(
+    [entry],
+    pathex=[here],
+    binaries=[],
+    datas=[],
+    hiddenimports=hidden,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=None)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    *assets_tree,
+    name='SolitaireSuite',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,   # windowed
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,  # set to a .ico/.icns path if you add one
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    *assets_tree,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='SolitaireSuite'
+)

--- a/scripts/package_macos_pyinstaller.sh
+++ b/scripts/package_macos_pyinstaller.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="onedir"  # change to onefile if desired (slower startup)
+
+if ! command -v pyinstaller >/dev/null 2>&1; then
+  echo "Installing PyInstaller..."
+  python3 -m pip install --user pyinstaller
+  export PATH="$HOME/Library/Python/$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/bin:$PATH"
+fi
+
+SPEC_DIR="$(cd "$(dirname "$0")/.." && pwd)/packaging/pyinstaller"
+SPEC_FILE="$SPEC_DIR/solitaire.spec"
+
+echo "Building using spec: $SPEC_FILE"
+if [[ "$MODE" == "onefile" ]]; then
+  pyinstaller --noconfirm --clean --onefile --windowed \
+    --name SolitaireSuite \
+    --add-data "src/solitaire/assets:solitaire/assets" \
+    src/solitaire/__main__.py
+else
+  pyinstaller --noconfirm --clean "$SPEC_FILE"
+fi
+
+echo "Build complete. See dist/SolitaireSuite. On macOS, you can bundle into a .app via --windowed."
+

--- a/scripts/package_windows_pyinstaller.ps1
+++ b/scripts/package_windows_pyinstaller.ps1
@@ -1,0 +1,25 @@
+param(
+  [string]$Mode = "onedir"  # or 'onefile'
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command pyinstaller -ErrorAction SilentlyContinue)) {
+  Write-Host "Installing PyInstaller..."
+  python -m pip install pyinstaller
+}
+
+$spec = Join-Path $PSScriptRoot "..\packaging\pyinstaller\solitaire.spec"
+Write-Host "Building using spec: $spec"
+
+if ($Mode -eq "onefile") {
+  # Onefile tends to be slower to start for Pygame; supported if desired
+  pyinstaller --noconfirm --clean --onefile --windowed --name SolitaireSuite `
+    --add-data "src/solitaire/assets;solitaire/assets" `
+    src/solitaire/__main__.py
+} else {
+  pyinstaller --noconfirm --clean $spec
+}
+
+Write-Host "Build complete. Output under 'dist/SolitaireSuite'"
+


### PR DESCRIPTION
Packaging/CI

Add PyInstaller spec and helper scripts for Windows/macOS
Spec robust to file absence; falls back to sys.argv[0]
Add GitHub Actions workflow to build and upload Win/macOS artifacts
Docs

Update README: FreeCell details, Settings UX, Hover Peek behavior,
Packaging instructions, Contributing guide, Known Issues