### PR TITLE
Route game scenes back to their option menus

### DIFF
--- a/src/solitaire/modes/golf.py
+++ b/src/solitaire/modes/golf.py
@@ -161,7 +161,7 @@ class GolfGameScene(C.Scene):
         # Toolbar
         def goto_menu():
             # Return without saving (discard progress)
-            from solitaire.modes.golf import GolfOptionsScene
+            from solitaire.scenes.game_options.golf_options import GolfOptionsScene
             self.next_scene = GolfOptionsScene(self.app)
 
         def can_undo():
@@ -356,7 +356,7 @@ class GolfGameScene(C.Scene):
         state = self._game_state()
         _safe_write_json(_golf_save_path(), state)
         if to_menu:
-            from solitaire.modes.golf import GolfOptionsScene
+            from solitaire.scenes.game_options.golf_options import GolfOptionsScene
             self.next_scene = GolfOptionsScene(self.app)
 
     def _load_from_state(self, state: Dict[str, Any]):
@@ -592,7 +592,7 @@ class GolfGameScene(C.Scene):
                 self._clamp_scroll()
         if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
             # ESC = back to options (no save)
-            from solitaire.modes.golf import GolfOptionsScene
+            from solitaire.scenes.game_options.golf_options import GolfOptionsScene
             self.next_scene = GolfOptionsScene(self.app)
             return
 
@@ -627,7 +627,7 @@ class GolfGameScene(C.Scene):
                 self._advance_to_next_hole()
                 return
             if self._is_game_complete() and self._finish_button_rect().collidepoint((mx, my)):
-                from solitaire.modes.golf import GolfOptionsScene
+                from solitaire.scenes.game_options.golf_options import GolfOptionsScene
                 self.next_scene = GolfOptionsScene(self.app)
                 return
 
@@ -879,10 +879,10 @@ class GolfScoresScene(C.Scene):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
             if self.b_back.hovered((mx, my)):
-                from solitaire.modes.golf import GolfOptionsScene
+                from solitaire.scenes.game_options.golf_options import GolfOptionsScene
                 self.next_scene = GolfOptionsScene(self.app)
         elif e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
-            from solitaire.modes.golf import GolfOptionsScene
+            from solitaire.scenes.game_options.golf_options import GolfOptionsScene
             self.next_scene = GolfOptionsScene(self.app)
 
     def draw(self, screen):

--- a/src/solitaire/modes/pyramid.py
+++ b/src/solitaire/modes/pyramid.py
@@ -95,8 +95,8 @@ class PyramidGameScene(C.Scene):
 
         # Toolbar (right-aligned)
         def _goto_menu():
-            from solitaire.scenes.menu import MainMenuScene
-            self.next_scene = MainMenuScene(self.app)
+            from solitaire.scenes.game_options.pyramid_options import PyramidOptionsScene
+            self.next_scene = PyramidOptionsScene(self.app)
 
         def _can_undo():
             return self.undo_mgr.can_undo()
@@ -602,8 +602,8 @@ class PyramidGameScene(C.Scene):
                 return
 
         if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
-            from solitaire.scenes.menu import MainMenuScene
-            self.next_scene = MainMenuScene(self.app)
+            from solitaire.scenes.game_options.pyramid_options import PyramidOptionsScene
+            self.next_scene = PyramidOptionsScene(self.app)
             return
         elif e.type == pygame.KEYDOWN and e.key == pygame.K_u:
             self.undo(); return

--- a/src/solitaire/modes/tripeaks.py
+++ b/src/solitaire/modes/tripeaks.py
@@ -97,8 +97,8 @@ class TriPeaksGameScene(C.Scene):
         self.message: str = ""
 
         def goto_menu():
-            from solitaire.scenes.menu import MainMenuScene
-            self.next_scene = MainMenuScene(self.app)
+            from solitaire.scenes.game_options.tripeaks_options import TriPeaksOptionsScene
+            self.next_scene = TriPeaksOptionsScene(self.app)
 
         def can_undo():
             return self.undo_mgr.can_undo()
@@ -571,8 +571,8 @@ class TriPeaksGameScene(C.Scene):
 
         if e.type == pygame.KEYDOWN:
             if e.key == pygame.K_ESCAPE:
-                from solitaire.scenes.menu import MainMenuScene
-                self.next_scene = MainMenuScene(self.app)
+                from solitaire.scenes.game_options.tripeaks_options import TriPeaksOptionsScene
+                self.next_scene = TriPeaksOptionsScene(self.app)
             elif e.key == pygame.K_n:
                 self.new_game()
             elif e.key == pygame.K_r:

--- a/src/solitaire/modes/yukon.py
+++ b/src/solitaire/modes/yukon.py
@@ -129,7 +129,7 @@ class YukonGameScene(C.Scene):
         # Toolbar
         def goto_menu():
             # Offer return to options; progress not auto-saved unless Save&Exit used
-            from solitaire.modes.yukon import YukonOptionsScene
+            from solitaire.scenes.game_options.yukon_options import YukonOptionsScene
             self.next_scene = YukonOptionsScene(self.app)
 
         def can_undo():
@@ -270,7 +270,7 @@ class YukonGameScene(C.Scene):
         state = self._state_dict()
         _safe_write_json(_yukon_save_path(), state)
         if to_menu:
-            from solitaire.modes.yukon import YukonOptionsScene
+            from solitaire.scenes.game_options.yukon_options import YukonOptionsScene
             self.next_scene = YukonOptionsScene(self.app)
 
     def _state_dict(self):
@@ -417,6 +417,11 @@ class YukonGameScene(C.Scene):
 
         # Do not interact while animation is running
         if self.anim.active:
+            return
+
+        if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
+            from solitaire.scenes.game_options.yukon_options import YukonOptionsScene
+            self.next_scene = YukonOptionsScene(self.app)
             return
 
         # Mouse wheel scroll


### PR DESCRIPTION
## Summary
- update the Golf, Pyramid, TriPeaks, and Yukon game scenes so the toolbar menu button and ESC key return to their respective option screens
- adjust Golf save/finish flows and the scores screen to import the option scene from its new module location
- ensure Yukon game scenes exit to the options screen when saving or pressing ESC

## Testing
- PYTHONPATH=src pytest *(fails: existing tests expect scripted scene transitions that are not yet satisfied)*

------
https://chatgpt.com/codex/tasks/task_e_68cee7ab485883218b22e976ae9c8a57