### PR TITLE
Fix options scene imports and toolbar navigation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ dependencies = ["pygame>=2.6"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/solitaire/modes/freecell.py
+++ b/src/solitaire/modes/freecell.py
@@ -42,8 +42,8 @@ class FreeCellGameScene(C.Scene):
 
         # Toolbar
         def goto_menu():
-            from solitaire.scenes.game_options.freecell_options import FreeCellOptionsScene
-            self.next_scene = FreeCellOptionsScene(self.app)
+            from solitaire.scenes.menu import MainMenuScene
+            self.next_scene = MainMenuScene(self.app)
 
         def can_undo():
             return self.undo_mgr.can_undo()
@@ -481,8 +481,8 @@ class FreeCellGameScene(C.Scene):
             elif e.key == pygame.K_a:
                 self.auto_to_foundations()
             elif e.key == pygame.K_ESCAPE:
-                from solitaire.scenes.game_options.freecell_options import FreeCellOptionsScene
-                self.next_scene = FreeCellOptionsScene(self.app)
+                from solitaire.scenes.menu import MainMenuScene
+                self.next_scene = MainMenuScene(self.app)
 
     # ----- Scroll helpers -----
     def _content_bottom_y(self) -> int:

--- a/src/solitaire/modes/gate.py
+++ b/src/solitaire/modes/gate.py
@@ -49,8 +49,8 @@ class GateGameScene(C.Scene):
 
         # Toolbar
         def goto_menu():
-            from solitaire.scenes.game_options.gate_options import GateOptionsScene
-            self.next_scene = GateOptionsScene(self.app)
+            from solitaire.scenes.menu import MainMenuScene
+            self.next_scene = MainMenuScene(self.app)
 
         def can_undo():
             return self.undo_mgr.can_undo()

--- a/src/solitaire/modes/golf.py
+++ b/src/solitaire/modes/golf.py
@@ -161,7 +161,7 @@ class GolfGameScene(C.Scene):
         # Toolbar
         def goto_menu():
             # Return without saving (discard progress)
-            from solitaire.modes.golf import GolfOptionsScene
+            from solitaire.scenes.game_options.golf_options import GolfOptionsScene
             self.next_scene = GolfOptionsScene(self.app)
 
         def can_undo():
@@ -356,7 +356,7 @@ class GolfGameScene(C.Scene):
         state = self._game_state()
         _safe_write_json(_golf_save_path(), state)
         if to_menu:
-            from solitaire.modes.golf import GolfOptionsScene
+            from solitaire.scenes.game_options.golf_options import GolfOptionsScene
             self.next_scene = GolfOptionsScene(self.app)
 
     def _load_from_state(self, state: Dict[str, Any]):
@@ -592,7 +592,7 @@ class GolfGameScene(C.Scene):
                 self._clamp_scroll()
         if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
             # ESC = back to options (no save)
-            from solitaire.modes.golf import GolfOptionsScene
+            from solitaire.scenes.game_options.golf_options import GolfOptionsScene
             self.next_scene = GolfOptionsScene(self.app)
             return
 
@@ -627,7 +627,7 @@ class GolfGameScene(C.Scene):
                 self._advance_to_next_hole()
                 return
             if self._is_game_complete() and self._finish_button_rect().collidepoint((mx, my)):
-                from solitaire.modes.golf import GolfOptionsScene
+                from solitaire.scenes.game_options.golf_options import GolfOptionsScene
                 self.next_scene = GolfOptionsScene(self.app)
                 return
 
@@ -879,10 +879,10 @@ class GolfScoresScene(C.Scene):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
             if self.b_back.hovered((mx, my)):
-                from solitaire.modes.golf import GolfOptionsScene
+                from solitaire.scenes.game_options.golf_options import GolfOptionsScene
                 self.next_scene = GolfOptionsScene(self.app)
         elif e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
-            from solitaire.modes.golf import GolfOptionsScene
+            from solitaire.scenes.game_options.golf_options import GolfOptionsScene
             self.next_scene = GolfOptionsScene(self.app)
 
     def draw(self, screen):

--- a/src/solitaire/modes/klondike.py
+++ b/src/solitaire/modes/klondike.py
@@ -36,8 +36,8 @@ class KlondikeGameScene(C.Scene):
 
         # Toolbar actions
         def goto_menu():
-            from solitaire.scenes.game_options.klondike_options import KlondikeOptionsScene
-            self.next_scene = KlondikeOptionsScene(self.app)
+            from solitaire.scenes.menu import MainMenuScene
+            self.next_scene = MainMenuScene(self.app)
 
         def can_undo():
             return self.undo_mgr.can_undo()
@@ -573,8 +573,8 @@ class KlondikeGameScene(C.Scene):
                 if self.can_autofinish():
                     self.start_auto_finish()
             elif e.key == pygame.K_ESCAPE:
-                from solitaire.scenes.game_options.klondike_options import KlondikeOptionsScene
-                self.next_scene = KlondikeOptionsScene(self.app)
+                from solitaire.scenes.menu import MainMenuScene
+                self.next_scene = MainMenuScene(self.app)
                 return
 
     # ---------- Drawing ----------

--- a/src/solitaire/modes/yukon.py
+++ b/src/solitaire/modes/yukon.py
@@ -129,7 +129,7 @@ class YukonGameScene(C.Scene):
         # Toolbar
         def goto_menu():
             # Offer return to options; progress not auto-saved unless Save&Exit used
-            from solitaire.modes.yukon import YukonOptionsScene
+            from solitaire.scenes.game_options.yukon_options import YukonOptionsScene
             self.next_scene = YukonOptionsScene(self.app)
 
         def can_undo():
@@ -270,7 +270,7 @@ class YukonGameScene(C.Scene):
         state = self._state_dict()
         _safe_write_json(_yukon_save_path(), state)
         if to_menu:
-            from solitaire.modes.yukon import YukonOptionsScene
+            from solitaire.scenes.game_options.yukon_options import YukonOptionsScene
             self.next_scene = YukonOptionsScene(self.app)
 
     def _state_dict(self):

--- a/src/solitaire/scenes/game_options/beleaguered_castle_options.py
+++ b/src/solitaire/scenes/game_options/beleaguered_castle_options.py
@@ -1,11 +1,6 @@
 import pygame
 from solitaire import common as C
-from solitaire.modes.beleaguered_castle import (
-    BeleagueredCastleGameScene,
-    _bc_save_path,
-    _safe_read_json,
-    _clear_saved_game,
-)
+from solitaire.modes import beleaguered_castle as beleaguered_castle_mode
 
 
 class BeleagueredCastleOptionsScene(C.Scene):
@@ -19,18 +14,18 @@ class BeleagueredCastleOptionsScene(C.Scene):
         self.b_back = C.Button("Back", cx, y, w=440)
 
     def _has_save(self) -> bool:
-        s = _safe_read_json(_bc_save_path())
+        s = beleaguered_castle_mode._safe_read_json(beleaguered_castle_mode._bc_save_path())
         return bool(s) and not s.get("completed", False)
 
     def handle_event(self, e):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
             if self.b_start.hovered((mx, my)):
-                _clear_saved_game()
-                self.next_scene = BeleagueredCastleGameScene(self.app, load_state=None)
+                beleaguered_castle_mode._clear_saved_game()
+                self.next_scene = beleaguered_castle_mode.BeleagueredCastleGameScene(self.app, load_state=None)
             elif self.b_resume.hovered((mx, my)) and self._has_save():
-                state = _safe_read_json(_bc_save_path())
-                self.next_scene = BeleagueredCastleGameScene(self.app, load_state=state)
+                state = beleaguered_castle_mode._safe_read_json(beleaguered_castle_mode._bc_save_path())
+                self.next_scene = beleaguered_castle_mode.BeleagueredCastleGameScene(self.app, load_state=state)
             elif self.b_back.hovered((mx, my)):
                 from solitaire.scenes.menu import MainMenuScene
                 self.next_scene = MainMenuScene(self.app)

--- a/src/solitaire/scenes/game_options/big_ben_options.py
+++ b/src/solitaire/scenes/game_options/big_ben_options.py
@@ -1,11 +1,6 @@
 import pygame
 from solitaire import common as C
-from solitaire.modes.big_ben import (
-    BigBenGameScene,
-    _bb_save_path,
-    _safe_read_json,
-    _clear_saved_game,
-)
+from solitaire.modes import big_ben as big_ben_mode
 
 
 class BigBenOptionsScene(C.Scene):
@@ -19,19 +14,19 @@ class BigBenOptionsScene(C.Scene):
         self.b_back = C.Button("Back", cx, y, w=440)
 
     def _has_save(self) -> bool:
-        state = _safe_read_json(_bb_save_path())
+        state = big_ben_mode._safe_read_json(big_ben_mode._bb_save_path())
         return bool(state) and not state.get("completed", False)
 
     def handle_event(self, e):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
             if self.b_start.hovered((mx, my)):
-                _clear_saved_game()
-                self.next_scene = BigBenGameScene(self.app, load_state=None)
+                big_ben_mode._clear_saved_game()
+                self.next_scene = big_ben_mode.BigBenGameScene(self.app, load_state=None)
             elif self.b_resume.hovered((mx, my)) and self._has_save():
-                state = _safe_read_json(_bb_save_path())
+                state = big_ben_mode._safe_read_json(big_ben_mode._bb_save_path())
                 if state:
-                    self.next_scene = BigBenGameScene(self.app, load_state=state)
+                    self.next_scene = big_ben_mode.BigBenGameScene(self.app, load_state=state)
             elif self.b_back.hovered((mx, my)):
                 from solitaire.scenes.menu import MainMenuScene
                 self.next_scene = MainMenuScene(self.app)

--- a/src/solitaire/scenes/game_options/freecell_options.py
+++ b/src/solitaire/scenes/game_options/freecell_options.py
@@ -1,6 +1,6 @@
 import pygame
 from solitaire import common as C
-from solitaire.modes.freecell import FreeCellGameScene
+from solitaire.modes import freecell as freecell_mode
 
 
 class FreeCellOptionsScene(C.Scene):
@@ -15,7 +15,7 @@ class FreeCellOptionsScene(C.Scene):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
             if self.b_start.hovered((mx, my)):
-                self.next_scene = FreeCellGameScene(self.app)
+                self.next_scene = freecell_mode.FreeCellGameScene(self.app)
             elif self.b_back.hovered((mx, my)):
                 from solitaire.scenes.menu import MainMenuScene
                 self.next_scene = MainMenuScene(self.app)

--- a/src/solitaire/scenes/game_options/gate_options.py
+++ b/src/solitaire/scenes/game_options/gate_options.py
@@ -1,6 +1,6 @@
 import pygame
 from solitaire import common as C
-from solitaire.modes.gate import GateGameScene
+from solitaire.modes import gate as gate_mode
 
 
 class GateOptionsScene(C.Scene):
@@ -15,7 +15,7 @@ class GateOptionsScene(C.Scene):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
             if self.b_start.hovered((mx, my)):
-                self.next_scene = GateGameScene(self.app)
+                self.next_scene = gate_mode.GateGameScene(self.app)
             elif self.b_back.hovered((mx, my)):
                 from solitaire.scenes.menu import MainMenuScene
                 self.next_scene = MainMenuScene(self.app)

--- a/src/solitaire/scenes/game_options/golf_options.py
+++ b/src/solitaire/scenes/game_options/golf_options.py
@@ -1,12 +1,7 @@
 import os
 import pygame
 from solitaire import common as C
-from solitaire.modes.golf import (
-    GolfGameScene,
-    GolfScoresScene,
-    _golf_save_path,
-    _safe_read_json,
-)
+from solitaire.modes import golf as golf_mode
 
 
 class GolfOptionsScene(C.Scene):
@@ -34,14 +29,20 @@ class GolfOptionsScene(C.Scene):
 
     def _start_new(self, holes: int):
         try:
-            if os.path.isfile(_golf_save_path()):
-                os.remove(_golf_save_path())
+            save_path = golf_mode._golf_save_path()
+            if os.path.isfile(save_path):
+                os.remove(save_path)
         except Exception:
             pass
-        self.next_scene = GolfGameScene(self.app, holes_total=holes, around=self.around, load_state=None)
+        self.next_scene = golf_mode.GolfGameScene(
+            self.app,
+            holes_total=holes,
+            around=self.around,
+            load_state=None,
+        )
 
     def _has_save(self) -> bool:
-        s = _safe_read_json(_golf_save_path())
+        s = golf_mode._safe_read_json(golf_mode._golf_save_path())
         return bool(s) and not s.get("completed", False)
 
     def handle_event(self, e):
@@ -59,10 +60,15 @@ class GolfOptionsScene(C.Scene):
                 self.around = not self.around
                 self.b_wrap.text = self._wrap_label()
             elif self.b_continue.hovered((mx, my)) and self._has_save():
-                load_state = _safe_read_json(_golf_save_path())
-                self.next_scene = GolfGameScene(self.app, holes_total=load_state.get("holes_total", 1), around=bool(load_state.get("around", False)), load_state=load_state)
+                load_state = golf_mode._safe_read_json(golf_mode._golf_save_path())
+                self.next_scene = golf_mode.GolfGameScene(
+                    self.app,
+                    holes_total=load_state.get("holes_total", 1),
+                    around=bool(load_state.get("around", False)),
+                    load_state=load_state,
+                )
             elif self.b_scores.hovered((mx, my)):
-                self.next_scene = GolfScoresScene(self.app)
+                self.next_scene = golf_mode.GolfScoresScene(self.app)
             elif self.b_back.hovered((mx, my)):
                 from solitaire.scenes.menu import MainMenuScene
                 self.next_scene = MainMenuScene(self.app)

--- a/src/solitaire/scenes/game_options/klondike_options.py
+++ b/src/solitaire/scenes/game_options/klondike_options.py
@@ -1,6 +1,6 @@
 import pygame
 from solitaire import common as C
-from solitaire.modes.klondike import KlondikeGameScene
+from solitaire.modes import klondike as klondike_mode
 
 
 class KlondikeOptionsScene(C.Scene):
@@ -20,7 +20,7 @@ class KlondikeOptionsScene(C.Scene):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx,my = e.pos
             if self.b_start.hovered((mx,my)):
-                self.next_scene = KlondikeGameScene(
+                self.next_scene = klondike_mode.KlondikeGameScene(
                     self.app,
                     draw_count=self.draw_mode,
                     stock_cycles=[None,2,1][self.diff_index]

--- a/src/solitaire/scenes/game_options/pyramid_options.py
+++ b/src/solitaire/scenes/game_options/pyramid_options.py
@@ -1,6 +1,6 @@
 import pygame
 from solitaire import common as C
-from solitaire.modes.pyramid import PyramidGameScene
+from solitaire.modes import pyramid as pyramid_mode
 
 
 class PyramidOptionsScene(C.Scene):
@@ -18,7 +18,7 @@ class PyramidOptionsScene(C.Scene):
             mx, my = e.pos
             if self.b_start.hovered((mx, my)):
                 allowed = [None, 2, 1][self.diff_index]
-                self.next_scene = PyramidGameScene(self.app, allowed_resets=allowed)
+                self.next_scene = pyramid_mode.PyramidGameScene(self.app, allowed_resets=allowed)
             elif self.b_diff.hovered((mx, my)):
                 self.diff_index = (self.diff_index + 1) % 3
                 text = ["Easy (Unlimited resets)", "Normal (2 resets)", "Hard (1 reset)"][self.diff_index]

--- a/src/solitaire/scenes/game_options/tripeaks_options.py
+++ b/src/solitaire/scenes/game_options/tripeaks_options.py
@@ -1,6 +1,6 @@
 import pygame
 from solitaire import common as C
-from solitaire.modes.tripeaks import TriPeaksGameScene
+from solitaire.modes import tripeaks as tripeaks_mode
 
 
 class TriPeaksOptionsScene(C.Scene):
@@ -17,7 +17,7 @@ class TriPeaksOptionsScene(C.Scene):
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx, my = e.pos
             if self.b_start.hovered((mx, my)):
-                self.next_scene = TriPeaksGameScene(self.app, wrap_ak=self.wrap_ak)
+                self.next_scene = tripeaks_mode.TriPeaksGameScene(self.app, wrap_ak=self.wrap_ak)
             elif self.b_wrap.hovered((mx, my)):
                 self.wrap_ak = not self.wrap_ak
                 self.b_wrap.text = f"Wrap A↔K: {'On' if self.wrap_ak else 'Off'}"

--- a/src/solitaire/scenes/game_options/yukon_options.py
+++ b/src/solitaire/scenes/game_options/yukon_options.py
@@ -1,11 +1,7 @@
 import os
 import pygame
 from solitaire import common as C
-from solitaire.modes.yukon import (
-    YukonGameScene,
-    _yukon_save_path,
-    _safe_read_json,
-)
+from solitaire.modes import yukon as yukon_mode
 
 
 class YukonOptionsScene(C.Scene):
@@ -19,7 +15,7 @@ class YukonOptionsScene(C.Scene):
         self.b_back = C.Button("Back", cx, y, w=440)
 
     def _has_save(self) -> bool:
-        s = _safe_read_json(_yukon_save_path())
+        s = yukon_mode._safe_read_json(yukon_mode._yukon_save_path())
         return bool(s) and not s.get("completed", False)
 
     def handle_event(self, e):
@@ -27,14 +23,15 @@ class YukonOptionsScene(C.Scene):
             mx, my = e.pos
             if self.b_start.hovered((mx, my)):
                 try:
-                    if os.path.isfile(_yukon_save_path()):
-                        os.remove(_yukon_save_path())
+                    save_path = yukon_mode._yukon_save_path()
+                    if os.path.isfile(save_path):
+                        os.remove(save_path)
                 except Exception:
                     pass
-                self.next_scene = YukonGameScene(self.app, load_state=None)
+                self.next_scene = yukon_mode.YukonGameScene(self.app, load_state=None)
             elif self.b_continue.hovered((mx, my)) and self._has_save():
-                state = _safe_read_json(_yukon_save_path())
-                self.next_scene = YukonGameScene(self.app, load_state=state)
+                state = yukon_mode._safe_read_json(yukon_mode._yukon_save_path())
+                self.next_scene = yukon_mode.YukonGameScene(self.app, load_state=state)
             elif self.b_back.hovered((mx, my)):
                 from solitaire.scenes.menu import MainMenuScene
                 self.next_scene = MainMenuScene(self.app)

--- a/src/solitaire/scenes/menu.py
+++ b/src/solitaire/scenes/menu.py
@@ -54,10 +54,10 @@ class MainMenuScene(C.Scene):
                 "title": "Packers",
                 "entries": [
                     _GameEntry("klondike", "Klondike", "icon_klondike.png", "solitaire.scenes.game_options.klondike_options", "KlondikeOptionsScene"),
-                    _GameEntry("freecell", "FreeCell", "icon_freecell.png", "solitaire.modes.freecell", "FreeCellOptionsScene"),
-                    _GameEntry("gate", "Gate", "icon_gate.png", "solitaire.modes.gate", "GateOptionsScene"),
+                    _GameEntry("freecell", "FreeCell", "icon_freecell.png", "solitaire.scenes.game_options.freecell_options", "FreeCellOptionsScene"),
+                    _GameEntry("gate", "Gate", "icon_gate.png", "solitaire.scenes.game_options.gate_options", "GateOptionsScene"),
                     _GameEntry("beleaguered_castle", "Beleaguered\nCastle", "icon_beleagured_castle.png", "solitaire.scenes.game_options.beleaguered_castle_options", "BeleagueredCastleOptionsScene"),
-                    _GameEntry("yukon", "Yukon", "icon_yukon.png", "solitaire.modes.yukon", "YukonOptionsScene"),
+                    _GameEntry("yukon", "Yukon", "icon_yukon.png", "solitaire.scenes.game_options.yukon_options", "YukonOptionsScene"),
                 ],
                 "rect": pygame.Rect(0, 0, 0, 0),
                 "title_surf": None,
@@ -66,10 +66,10 @@ class MainMenuScene(C.Scene):
             {
                 "title": "Builders",
                 "entries": [
-                    _GameEntry("big_ben", "Big Ben", "icon_big_ben.png", "solitaire.modes.big_ben", "BigBenOptionsScene"),
-                    _GameEntry("golf", "Golf", "icon_golf.png", "solitaire.modes.golf", "GolfOptionsScene"),
-                    _GameEntry("pyramid", "Pyramid", "icon_pyramid.png", "solitaire.modes.pyramid", "PyramidOptionsScene"),
-                    _GameEntry("tripeaks", "TriPeaks", "icon_tripeaks.png", "solitaire.modes.tripeaks", "TriPeaksOptionsScene"),
+                    _GameEntry("big_ben", "Big Ben", "icon_big_ben.png", "solitaire.scenes.game_options.big_ben_options", "BigBenOptionsScene"),
+                    _GameEntry("golf", "Golf", "icon_golf.png", "solitaire.scenes.game_options.golf_options", "GolfOptionsScene"),
+                    _GameEntry("pyramid", "Pyramid", "icon_pyramid.png", "solitaire.scenes.game_options.pyramid_options", "PyramidOptionsScene"),
+                    _GameEntry("tripeaks", "TriPeaks", "icon_tripeaks.png", "solitaire.scenes.game_options.tripeaks_options", "TriPeaksOptionsScene"),
                 ],
                 "rect": pygame.Rect(0, 0, 0, 0),
                 "title_surf": None,


### PR DESCRIPTION
## Summary
- make pytest aware of the src layout so the solitaire package can be imported during tests
- update option scene modules to reference their game scenes via the mode modules and align the main menu entries with the new module locations
- adjust in-game toolbar navigation so games that should exit to the main menu do so while Golf and Yukon return to their options scenes through the new module path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cee8412eb48321bb03fb70656de3d3