### PR TITLE
Extract help text into localized JSON data

### DIFF
--- a/src/solitaire/assets/help/help_en.json
+++ b/src/solitaire/assets/help/help_en.json
@@ -1,0 +1,120 @@
+{
+  "big_ben": {
+    "title": "Big Ben - How to Play",
+    "lines": [
+      "Goal: Build each foundation to its clock value using cards of the same suit.",
+      "Setup: One copy of the highlighted cards forms the twelve foundations arranged like a clock (starting at the 9 o'clock position).",
+      "Tableau: Each foundation has an outward fan of up to three face-up cards. The outermost card of a fan is the only card that may move.",
+      "Tableau moves: Move a fan's top card onto another fan when it is exactly one rank lower (wrapping K->A) and the same suit.",
+      "Foundations: Build upward by suit from the starting card, wrapping K->A, until the foundation's clock rank is on top. Waste cards may also be played here.",
+      "Stock: Click the stock to refill every fan with fewer than three cards (starting at 12 o'clock clockwise). If no fan needs cards, the click moves the top stock card to the waste face-up.",
+      "Waste: Its top card can only be played to foundations. It never refills tableau fans.",
+      "End: Win when all foundations reach their clock rank. Lose when the stock is empty and there are no legal moves left.",
+      "Toolbar: Menu (return to Big Ben menu), New deal, Restart, Undo, Help, Save&Exit."
+    ],
+    "max_width": 880
+  },
+  "beleaguered_castle": {
+    "title": "Beleaguered Castle - How to Play",
+    "lines": [
+      "Goal: Build each foundation from Ace to King in the same suit.",
+      "Setup: All four aces start on the central foundations. The remaining 48 cards are dealt face-up into eight rows of six cards that flank each foundation (left and right).",
+      "Moves: You may move only the exposed bottom card of any row. Place it onto another row when its rank is exactly one less than the target card, regardless of suit. Empty rows may be filled by any single card.",
+      "Foundations: When a top card is the next rank for its suited foundation, double-click it (or drag it) to build upward. Foundations build A->K and cannot move back to the tableau.",
+      "Controls: Toolbar buttons provide New Deal, Restart, Undo, Auto-complete, Help, Save & Exit, and return to the menu. Auto-complete becomes available when every tableau row is already in perfect descending order."
+    ],
+    "max_width": 860
+  },
+  "freecell": {
+    "title": "FreeCell — How to Play",
+    "lines": [
+      "Goal: Build up four foundations A→K by suit.",
+      "Tableau: Build down by rank with alternating colors.",
+      "Empty column accepts any card or a valid descending run.",
+      "Free cells: Four cells each hold one card to help maneuver.",
+      "You can drag runs; movable length depends on empty cells and columns.",
+      "Double-click a safe top card to move to a foundation.",
+      "Use Auto to move obvious cards to foundations. Undo/Restart available.",
+      "Press H to close this help."
+    ]
+  },
+  "gate": {
+    "title": "Gate — How to Play",
+    "lines": [
+      "Goal: Build four foundations A→K by suit.",
+      "Layout: 8 center tableau piles (2×4) build down with alternating colors.",
+      "Reserves: Two side reserves start with 5 face-up cards; you cannot place onto reserves.",
+      "You may move a reserve top card to a center pile or to its foundation.",
+      "Stock/Waste: Click stock to draw 1 to waste (no redeals).",
+      "When a center pile is emptied it auto-fills from Stock, else from Waste.",
+      "If both are empty it stays empty; you may fill it from a reserve.",
+      "Double-click eligible tops to foundations. Auto-finish available.",
+      "Press H/Esc to close this help."
+    ]
+  },
+  "golf": {
+    "title": "Golf — How to Play",
+    "lines": [
+      "Goal: Clear tableau piles across 1/3/9/18 holes for a low total score.",
+      "Play: Move the top card of any tableau pile to the foundation",
+      "if it is one rank higher or lower than the foundation top (suit doesn't matter).",
+      "Wrap A↔K is controlled by the Around-the-Corner option on the options screen.",
+      "Stock: Flip one to the foundation to start, and when stuck. No redeals.",
+      "Scoring: If tableau is cleared, score = -remaining stock; else = remaining tableau count.",
+      "Save&Exit lets you continue later; recent totals shown in Scores.",
+      "Undo/Restart available from the toolbar. Press Esc/Close to dismiss help."
+    ]
+  },
+  "klondike": {
+    "title": "Klondike — How to Play",
+    "lines": [
+      "Goal: Build up four foundations A→K by suit.",
+      "Tableau: Build down by rank with alternating colors.",
+      "You may drag sequences that follow alternating colors.",
+      "Empty column: Only a King or a stack starting with King.",
+      "Stock/Waste: Click stock to deal 1 or 3 cards depending on Draw setting.",
+      "Redeals depend on Difficulty: Easy=unlimited, Medium=2, Hard=1.",
+      "Double-click a top card to auto-move to a foundation if legal.",
+      "Use Auto to auto-finish when eligible. Undo/Restart from toolbar.",
+      "Press H to close this help."
+    ]
+  },
+  "pyramid": {
+    "title": "Pyramid — How to Play",
+    "lines": [
+      "Goal: Remove all cards by making pairs that sum to 13.",
+      "Kings (13) remove by themselves.",
+      "Only uncovered (exposed) cards can be paired.",
+      "Use the two waste piles under the stock; pair with wastes when possible.",
+      "Stock: Click to deal to waste. Resets allowed depend on difficulty:",
+      "Easy=unlimited, Normal=2, Hard=1.",
+      "Use Hint to highlight a possible pair. Undo/Restart available.",
+      "Press H to close this help."
+    ]
+  },
+  "tripeaks": {
+    "title": "TriPeaks — How to Play",
+    "lines": [
+      "Goal: Clear all tableau cards.",
+      "Move any exposed card that is one rank higher or lower",
+      "than the waste top (suit does not matter).",
+      "Wrap A↔K is controlled by the Wrap option on the options screen.",
+      "Click stock to deal the next card to waste; no redeals.",
+      "Use Hint to highlight a playable card. Undo/Restart available.",
+      "Press Esc or Close to dismiss this help."
+    ]
+  },
+  "yukon": {
+    "title": "Yukon — How to Play",
+    "lines": [
+      "Goal: Build four foundations A→K by suit.",
+      "Layout: 7 tableau piles with counts 1,6,7,8,9,10,11 (top 5 face-up).",
+      "Move: Drag any face-up substack; it need not be ordered.",
+      "Target: Bottom card must be one rank lower and opposite color than the destination top.",
+      "Empty column: Only Kings (or stacks starting with King).",
+      "Aces auto-move to foundations when exposed. Double-click top to send to foundation.",
+      "Auto completes when all tableau cards are face-up.",
+      "Use Save&Exit to continue later."
+    ]
+  }
+}

--- a/src/solitaire/help_data.py
+++ b/src/solitaire/help_data.py
@@ -1,0 +1,91 @@
+"""Localized help content for solitaire modes."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Dict, Iterable, Mapping, Optional, Tuple
+
+DEFAULT_HELP_LOCALE = "en"
+_HELP_FILENAME_TEMPLATE = "help_{locale}.json"
+_HELP_DIR = os.path.join(os.path.dirname(__file__), "assets", "help")
+
+
+@dataclass(frozen=True)
+class HelpContent:
+    """Immutable container for help metadata for a solitaire mode."""
+
+    title: str
+    lines: Tuple[str, ...]
+    max_width: Optional[int] = None
+
+    def as_modal_args(self) -> Tuple[str, Tuple[str, ...], Optional[int]]:
+        """Return positional arguments for :class:`solitaire.ui.ModalHelp`."""
+
+        return self.title, self.lines, self.max_width
+
+
+def _help_file_path(locale: str) -> str:
+    filename = _HELP_FILENAME_TEMPLATE.format(locale=locale)
+    return os.path.join(_HELP_DIR, filename)
+
+
+@lru_cache()
+def _load_locale(locale: str) -> Dict[str, HelpContent]:
+    path = _help_file_path(locale)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive guard
+        raise FileNotFoundError(f"Help locale '{locale}' not found at {path}") from exc
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"Help file {path} must contain an object mapping game ids to entries")
+
+    entries: Dict[str, HelpContent] = {}
+    for key, value in raw.items():
+        if not isinstance(value, Mapping):
+            raise TypeError(f"Help entry for '{key}' must be a mapping")
+        title = value.get("title")
+        lines = value.get("lines")
+        max_width = value.get("max_width")
+        if not isinstance(title, str):
+            raise TypeError(f"Help entry for '{key}' is missing a string 'title'")
+        if not isinstance(lines, Iterable) or isinstance(lines, (str, bytes)):
+            raise TypeError(f"Help entry for '{key}' must provide a list of help lines")
+        normalised_lines = []
+        for line in lines:
+            if not isinstance(line, str):
+                raise TypeError(f"Help entry for '{key}' contains a non-string line: {line!r}")
+            normalised_lines.append(line)
+        if max_width is not None and not isinstance(max_width, int):
+            raise TypeError(f"Help entry for '{key}' has non-integer max_width")
+        entries[key] = HelpContent(title=title, lines=tuple(normalised_lines), max_width=max_width)
+    return entries
+
+
+def get_help_content(game_id: str, *, locale: str = DEFAULT_HELP_LOCALE) -> HelpContent:
+    """Return the help content for the given solitaire mode."""
+
+    entries = _load_locale(locale)
+    try:
+        return entries[game_id]
+    except KeyError as exc:
+        raise KeyError(f"No help content defined for game id '{game_id}' and locale '{locale}'") from exc
+
+
+def available_help_ids(*, locale: str = DEFAULT_HELP_LOCALE) -> Tuple[str, ...]:
+    """Return all game ids with help available for the requested locale."""
+
+    return tuple(_load_locale(locale).keys())
+
+
+def create_modal_help(game_id: str, *, locale: str = DEFAULT_HELP_LOCALE):
+    """Construct a :class:`solitaire.ui.ModalHelp` using stored help content."""
+
+    from solitaire.ui import ModalHelp
+
+    content = get_help_content(game_id, locale=locale)
+    kwargs = {"max_width": content.max_width} if content.max_width is not None else {}
+    return ModalHelp(content.title, list(content.lines), **kwargs)

--- a/src/solitaire/modes/beleaguered_castle.py
+++ b/src/solitaire/modes/beleaguered_castle.py
@@ -6,7 +6,7 @@ import pygame
 
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 from solitaire import mechanics as M
 
 
@@ -79,17 +79,7 @@ class BeleagueredCastleGameScene(C.Scene):
         self._last_click_time = 0
         self._last_click_pos = (0, 0)
         # Help modal
-        self.help = ModalHelp(
-            "Beleaguered Castle - How to Play",
-            [
-                "Goal: Build each foundation from Ace to King in the same suit.",
-                "Setup: All four aces start on the central foundations. The remaining 48 cards are dealt face-up into eight rows of six cards that flank each foundation (left and right).",
-                "Moves: You may move only the exposed bottom card of any row. Place it onto another row when its rank is exactly one less than the target card, regardless of suit. Empty rows may be filled by any single card.",
-                "Foundations: When a top card is the next rank for its suited foundation, double-click it (or drag it) to build upward. Foundations build A->K and cannot move back to the tableau.",
-                "Controls: Toolbar buttons provide New Deal, Restart, Undo, Auto-complete, Help, Save & Exit, and return to the menu. Auto-complete becomes available when every tableau row is already in perfect descending order.",
-            ],
-            max_width=860,
-        )
+        self.help = create_modal_help("beleaguered_castle")
         # Edge panning while dragging (both axes)
         self.edge_pan = M.EdgePanDuringDrag(edge_margin_px=28, top_inset_px=getattr(C, "TOP_BAR_H", 60))
 

--- a/src/solitaire/modes/big_ben.py
+++ b/src/solitaire/modes/big_ben.py
@@ -8,7 +8,7 @@ import pygame
 
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 from solitaire import mechanics as M
 
 
@@ -130,21 +130,7 @@ class BigBenGameScene(C.Scene):
             menu_tooltip="Return to Big Ben menu",
         )
 
-        self.help = ModalHelp(
-            "Big Ben - How to Play",
-            [
-                "Goal: Build each foundation to its clock value using cards of the same suit.",
-                "Setup: One copy of the highlighted cards forms the twelve foundations arranged like a clock (starting at the 9 o'clock position).",
-                "Tableau: Each foundation has an outward fan of up to three face-up cards. The outermost card of a fan is the only card that may move.",
-                "Tableau moves: Move a fan's top card onto another fan when it is exactly one rank lower (wrapping K->A) and the same suit.",
-                "Foundations: Build upward by suit from the starting card, wrapping K->A, until the foundation's clock rank is on top. Waste cards may also be played here.",
-                "Stock: Click the stock to refill every fan with fewer than three cards (starting at 12 o'clock clockwise). If no fan needs cards, the click moves the top stock card to the waste face-up.",
-                "Waste: Its top card can only be played to foundations. It never refills tableau fans.",
-                "End: Win when all foundations reach their clock rank. Lose when the stock is empty and there are no legal moves left.",
-                "Toolbar: Menu (return to Big Ben menu), New deal, Restart, Undo, Help, Save&Exit.",
-            ],
-            max_width=880,
-        )
+        self.help = create_modal_help("big_ben")
         self.peek = M.PeekController(delay_ms=500)
         # Central edge-panning controller (for drag-to-edge auto-scroll)
         self.edge_pan = M.EdgePanDuringDrag(edge_margin_px=28, top_inset_px=getattr(C, "TOP_BAR_H", 60))

--- a/src/solitaire/modes/freecell.py
+++ b/src/solitaire/modes/freecell.py
@@ -3,7 +3,7 @@ import pygame
 from typing import List, Optional, Tuple
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 from solitaire import mechanics as M
 
 
@@ -41,7 +41,7 @@ class FreeCellGameScene(C.Scene):
         # Undo manager
         self.undo_mgr = C.UndoManager()
 
-        self.ui_helper = ModeUIHelper(self, game_id="freecell")
+        self.ui_helper = ModeUIHelper(self, game_id="freecell", return_to_options=False)
 
         def can_undo():
             return self.undo_mgr.can_undo()
@@ -62,19 +62,7 @@ class FreeCellGameScene(C.Scene):
         self._last_click_pos = (0, 0)
 
         # Help overlay
-        self.help = ModalHelp(
-            "FreeCell — How to Play",
-            [
-                "Goal: Build up four foundations A→K by suit.",
-                "Tableau: Build down by rank with alternating colors.",
-                "Empty column accepts any card or a valid descending run.",
-                "Free cells: Four cells each hold one card to help maneuver.",
-                "You can drag runs; movable length depends on empty cells and columns.",
-                "Double-click a safe top card to move to a foundation.",
-                "Use Auto to move obvious cards to foundations. Undo/Restart available.",
-                "Press H to close this help.",
-            ],
-        )
+        self.help = create_modal_help("freecell")
         # Edge panning while dragging near screen edges
         self.edge_pan = M.EdgePanDuringDrag(edge_margin_px=28, top_inset_px=getattr(C, "TOP_BAR_H", 60))
 

--- a/src/solitaire/modes/gate.py
+++ b/src/solitaire/modes/gate.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 from solitaire import mechanics as M
 
 
@@ -48,7 +48,7 @@ class GateGameScene(C.Scene):
         self.message: str = ""
         self.undo_mgr = C.UndoManager()
 
-        self.ui_helper = ModeUIHelper(self, game_id="gate")
+        self.ui_helper = ModeUIHelper(self, game_id="gate", return_to_options=False)
 
         def can_undo():
             return self.undo_mgr.can_undo()
@@ -68,20 +68,7 @@ class GateGameScene(C.Scene):
         self.compute_layout()
         self.deal_new()
         # Help overlay
-        self.help = ModalHelp(
-            "Gate — How to Play",
-            [
-                "Goal: Build four foundations A→K by suit.",
-                "Layout: 8 center tableau piles (2×4) build down with alternating colors.",
-                "Reserves: Two side reserves start with 5 face-up cards; you cannot place onto reserves.",
-                "You may move a reserve top card to a center pile or to its foundation.",
-                "Stock/Waste: Click stock to draw 1 to waste (no redeals).",
-                "When a center pile is emptied it auto-fills from Stock, else from Waste.",
-                "If both are empty it stays empty; you may fill it from a reserve.",
-                "Double-click eligible tops to foundations. Auto-finish available.",
-                "Press H/Esc to close this help.",
-            ],
-        )
+        self.help = create_modal_help("gate")
 
         # Double-click tracking (to foundations)
         self._last_click_time = 0

--- a/src/solitaire/modes/golf.py
+++ b/src/solitaire/modes/golf.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple, Dict, Any
 
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 
 
 def _golf_dir() -> str:
@@ -183,19 +183,7 @@ class GolfGameScene(C.Scene):
             self.deal_new_hole()
 
         # Help overlay
-        self.help = ModalHelp(
-            "Golf — How to Play",
-            [
-                "Goal: Clear tableau piles across 1/3/9/18 holes for a low total score.",
-                "Play: Move the top card of any tableau pile to the foundation",
-                "if it is one rank higher or lower than the foundation top (suit doesn't matter).",
-                "Wrap A↔K is controlled by the Around-the-Corner option on the options screen.",
-                "Stock: Flip one to the foundation to start, and when stuck. No redeals.",
-                "Scoring: If tableau is cleared, score = -remaining stock; else = remaining tableau count.",
-                "Save&Exit lets you continue later; recent totals shown in Scores.",
-                "Undo/Restart available from the toolbar. Press Esc/Close to dismiss help.",
-            ],
-        )
+        self.help = create_modal_help("golf")
 
         # Lazy-load golf placeholder image
         self._golf_img_raw: Optional[pygame.Surface] = None

--- a/src/solitaire/modes/klondike.py
+++ b/src/solitaire/modes/klondike.py
@@ -2,7 +2,7 @@
 import pygame
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 from solitaire import mechanics as M
 
 def is_red(suit): return suit in (1,2)
@@ -35,7 +35,7 @@ class KlondikeGameScene(C.Scene):
         self.message = ""
         self.drag_stack = None
 
-        self.ui_helper = ModeUIHelper(self, game_id="klondike")
+        self.ui_helper = ModeUIHelper(self, game_id="klondike", return_to_options=False)
 
         def can_undo():
             return self.undo_mgr.can_undo()
@@ -63,20 +63,7 @@ class KlondikeGameScene(C.Scene):
         # Hover peek for face-up cards within a pile
 
         # Help overlay
-        self.help = ModalHelp(
-            "Klondike — How to Play",
-            [
-                "Goal: Build up four foundations A→K by suit.",
-                "Tableau: Build down by rank with alternating colors.",
-                "You may drag sequences that follow alternating colors.",
-                "Empty column: Only a King or a stack starting with King.",
-                "Stock/Waste: Click stock to deal 1 or 3 cards depending on Draw setting.",
-                "Redeals depend on Difficulty: Easy=unlimited, Medium=2, Hard=1.",
-                "Double-click a top card to auto-move to a foundation if legal.",
-                "Use Auto to auto-finish when eligible. Undo/Restart from toolbar.",
-                "Press H to close this help.",
-            ],
-        )
+        self.help = create_modal_help("klondike")
         # Klondike-style delayed single-card peek (shared across modes)
         self.peek = M.PeekController(delay_ms=2000)
         # Central edge-panning controller for drag-to-edge auto-scroll

--- a/src/solitaire/modes/pyramid.py
+++ b/src/solitaire/modes/pyramid.py
@@ -5,7 +5,7 @@ import os
 from typing import List, Optional, Tuple
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 
 # Helper value rules
 def card_value(card: C.Card) -> int:
@@ -95,7 +95,7 @@ class PyramidGameScene(C.Scene):
         self.undo_mgr = C.UndoManager()
 
         # Toolbar (right-aligned)
-        self.ui_helper = ModeUIHelper(self, game_id="pyramid")
+        self.ui_helper = ModeUIHelper(self, game_id="pyramid", return_to_options=False)
 
         def _can_undo():
             return self.undo_mgr.can_undo()
@@ -137,19 +137,7 @@ class PyramidGameScene(C.Scene):
         self.push_undo()
 
         # Help overlay
-        self.help = ModalHelp(
-            "Pyramid — How to Play",
-            [
-                "Goal: Remove all cards by making pairs that sum to 13.",
-                "Kings (13) remove by themselves.",
-                "Only uncovered (exposed) cards can be paired.",
-                "Use the two waste piles under the stock; pair with wastes when possible.",
-                "Stock: Click to deal to waste. Resets allowed depend on difficulty:",
-                "Easy=unlimited, Normal=2, Hard=1.",
-                "Use Hint to highlight a possible pair. Undo/Restart available.",
-                "Press H to close this help.",
-            ],
-        )
+        self.help = create_modal_help("pyramid")
 
     # ---------- Scrolling helpers ----------
     def _content_bottom_y(self) -> int:

--- a/src/solitaire/modes/tripeaks.py
+++ b/src/solitaire/modes/tripeaks.py
@@ -15,7 +15,7 @@ from typing import List, Optional, Tuple
 import pygame
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 
 
 def rank_adjacent(a: int, b: int) -> bool:
@@ -97,7 +97,7 @@ class TriPeaksGameScene(C.Scene):
         self.undo_mgr = C.UndoManager()
         self.message: str = ""
 
-        self.ui_helper = ModeUIHelper(self, game_id="tripeaks")
+        self.ui_helper = ModeUIHelper(self, game_id="tripeaks", return_to_options=False)
 
         def can_undo():
             return self.undo_mgr.can_undo()
@@ -130,18 +130,7 @@ class TriPeaksGameScene(C.Scene):
         self.push_undo()
 
         # Help overlay
-        self.help = ModalHelp(
-            "TriPeaks — How to Play",
-            [
-                "Goal: Clear all tableau cards.",
-                "Move any exposed card that is one rank higher or lower",
-                "than the waste top (suit does not matter).",
-                "Wrap A↔K is controlled by the Wrap option on the options screen.",
-                "Click stock to deal the next card to waste; no redeals.",
-                "Use Hint to highlight a playable card. Undo/Restart available.",
-                "Press Esc or Close to dismiss this help.",
-            ],
-        )
+        self.help = create_modal_help("tripeaks")
 
     # ---------- Layout ----------
     def compute_layout(self):

--- a/src/solitaire/modes/yukon.py
+++ b/src/solitaire/modes/yukon.py
@@ -6,7 +6,7 @@ import pygame
 
 from solitaire import common as C
 from solitaire.modes.base_scene import ModeUIHelper
-from solitaire.ui import ModalHelp
+from solitaire.help_data import create_modal_help
 from solitaire import mechanics as M
 
 
@@ -161,19 +161,7 @@ class YukonGameScene(C.Scene):
             self.deal_new()
 
         # Help overlay
-        self.help = ModalHelp(
-            "Yukon — How to Play",
-            [
-                "Goal: Build four foundations A→K by suit.",
-                "Layout: 7 tableau piles with counts 1,6,7,8,9,10,11 (top 5 face-up).",
-                "Move: Drag any face-up substack; it need not be ordered.",
-                "Target: Bottom card must be one rank lower and opposite color than the destination top.",
-                "Empty column: Only Kings (or stacks starting with King).",
-                "Aces auto-move to foundations when exposed. Double-click top to send to foundation.",
-                "Auto completes when all tableau cards are face-up.",
-                "Use Save&Exit to continue later.",
-            ],
-        )
+        self.help = create_modal_help("yukon")
 
         # Double-click tracking
         self._last_click_time = 0


### PR DESCRIPTION
## Summary
- move all mode help text into a new `help_en.json` asset for easier localisation
- add a `solitaire.help_data` helper that loads help entries and can build a `ModalHelp`
- update every game mode to source help content from the shared loader and ensure quick-play games return directly to the main menu when the toolbar menu is used

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cef92324e48321be375c344bbfcd13