### PR TITLE
Add hamburger toolbar menu for shared game actions

### DIFF
--- a/src/solitaire/ui.py
+++ b/src/solitaire/ui.py
@@ -1,5 +1,6 @@
 # ui.py
 import pygame
+from dataclasses import dataclass
 from typing import Callable, Dict, Optional, List, Tuple
 from solitaire import common as C
 
@@ -18,8 +19,18 @@ BTN_BG_DISABLED = (200, 200, 205)
 BTN_BORDER = (160, 160, 170)
 BTN_TEXT = (30, 30, 35)
 BTN_TEXT_DISABLED = (120, 120, 130)
+MENU_PANEL_BG = (245, 245, 250)
 
 FONT = pygame.font.SysFont("Segoe UI", 18)
+
+
+@dataclass
+class MenuItem:
+    label: str
+    on_click: Callable[[], None]
+    enabled: Optional[Callable[[], bool] | bool] = None
+    tooltip: Optional[str] = None
+
 
 class Button:
     def __init__(
@@ -118,32 +129,234 @@ class Toolbar:
         for b in self.buttons:
             b.draw(surface)
 
+class HamburgerMenuButton(Button):
+    """Toolbar button that expands into a drop-down menu of actions."""
+
+    def __init__(
+        self,
+        items: List[MenuItem],
+        *,
+        height: int = DEFAULT_BUTTON_HEIGHT,
+        tooltip: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            label="Menu",
+            on_click=self._toggle_menu,
+            height=height,
+            min_width=max(height, 32),
+            tooltip=tooltip,
+        )
+        self._display_label = "☰"
+        # Compact width for icon presentation
+        compact_w = max(height, 32)
+        self.rect.size = (compact_w, self.rect.height)
+        self.items: List[MenuItem] = items
+        self._open: bool = False
+        self._panel_padding: int = 6
+        self._item_rects: List[pygame.Rect] = []
+        self._panel_rect = pygame.Rect(0, 0, 0, 0)
+        self._menu_hover_index: int = -1
+        self._item_height: int = height
+        self._menu_width: int = self.rect.width
+        self._update_menu_geometry()
+
+    def _toggle_menu(self) -> None:
+        if not self.items:
+            return
+        if not self._open:
+            self._update_menu_geometry()
+        self._open = not self._open
+        if not self._open:
+            self._menu_hover_index = -1
+
+    def set_position(self, x: int, y: int):
+        super().set_position(x, y)
+        self._item_height = self.rect.height
+        if self._open:
+            self._open = False
+            self._menu_hover_index = -1
+        self._update_menu_geometry()
+
+    def _update_menu_geometry(self) -> None:
+        if not self.items:
+            self._panel_rect.size = (0, 0)
+            self._item_rects = []
+            return
+
+        text_widths = [FONT.render(item.label, True, BTN_TEXT).get_width() for item in self.items]
+        content_width = max([self.rect.width] + [w + DEFAULT_BUTTON_PADDING_X * 2 for w in text_widths])
+        padding = self._panel_padding
+        panel_width = content_width + padding * 2
+        panel_height = self._item_height * len(self.items) + padding * 2
+
+        left = self.rect.right - panel_width
+        left = max(0, min(left, C.SCREEN_W - panel_width))
+        top_below = self.rect.bottom + 4
+        top_above = self.rect.top - 4 - panel_height
+        if top_below + panel_height <= C.SCREEN_H:
+            top = max(0, top_below)
+        elif top_above >= 0:
+            top = top_above
+        else:
+            top = max(0, min(top_below, C.SCREEN_H - panel_height))
+
+        self._panel_rect = pygame.Rect(left, top, panel_width, panel_height)
+        item_left = left + padding
+        item_top = top + padding
+        self._menu_width = content_width
+        self._item_rects = []
+        for index in range(len(self.items)):
+            rect = pygame.Rect(item_left, item_top + index * self._item_height, content_width, self._item_height)
+            self._item_rects.append(rect)
+
+    @staticmethod
+    def _item_enabled(item: MenuItem) -> bool:
+        if item.enabled is None:
+            return True
+        if callable(item.enabled):
+            try:
+                return bool(item.enabled())
+            except Exception:
+                return False
+        return bool(item.enabled)
+
+    def _hit_test(self, pos: Tuple[int, int]) -> Optional[int]:
+        for idx, rect in enumerate(self._item_rects):
+            if rect.collidepoint(pos):
+                return idx
+        return None
+
+    def handle_event(self, event: pygame.event.Event) -> bool:
+        if event.type == pygame.MOUSEMOTION:
+            super().handle_event(event)
+            if self._open:
+                hovered = self._hit_test(event.pos)
+                self._menu_hover_index = hovered if hovered is not None else -1
+            else:
+                self._menu_hover_index = -1
+            return False
+
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self._open:
+                if self._panel_rect.collidepoint(event.pos):
+                    idx = self._hit_test(event.pos)
+                    if idx is not None:
+                        item = self.items[idx]
+                        if self._item_enabled(item) and callable(item.on_click):
+                            item.on_click()
+                        self._open = False
+                        self._menu_hover_index = -1
+                    else:
+                        self._open = False
+                        self._menu_hover_index = -1
+                    return True
+                elif not self.rect.collidepoint(event.pos):
+                    self._open = False
+                    self._menu_hover_index = -1
+                    return False
+            handled = super().handle_event(event)
+            return handled
+
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE and self._open:
+            self._open = False
+            self._menu_hover_index = -1
+            return True
+
+        return super().handle_event(event)
+
+    def draw(self, surface: pygame.Surface):
+        original_label = self.label
+        self.label = self._display_label
+        super().draw(surface)
+        self.label = original_label
+        if not (self._open and self.items and self._panel_rect.width > 0):
+            return
+
+        pygame.draw.rect(surface, MENU_PANEL_BG, self._panel_rect, border_radius=8)
+        pygame.draw.rect(surface, BTN_BORDER, self._panel_rect, width=1, border_radius=8)
+
+        for idx, rect in enumerate(self._item_rects):
+            item = self.items[idx]
+            inner = rect.inflate(-2, -2)
+            enabled = self._item_enabled(item)
+            if not enabled:
+                bg = BTN_BG_DISABLED
+            elif idx == self._menu_hover_index:
+                bg = BTN_BG_HOVER
+            else:
+                bg = BTN_BG
+            pygame.draw.rect(surface, bg, inner, border_radius=6)
+
+            text_color = BTN_TEXT if enabled else BTN_TEXT_DISABLED
+            label_surf = FONT.render(item.label, True, text_color)
+            surface.blit(
+                label_surf,
+                (inner.left + DEFAULT_BUTTON_PADDING_X,
+                 inner.centery - label_surf.get_height() // 2),
+            )
+
+    def get_menu_item_rect(self, label: str) -> Optional[pygame.Rect]:
+        """Return the rect of a drop-down entry matching *label* (if available)."""
+
+        if not self.items:
+            return None
+        self._update_menu_geometry()
+        for idx, item in enumerate(self.items):
+            if item.label == label and idx < len(self._item_rects):
+                return self._item_rects[idx].copy()
+        return None
+
+
 def make_toolbar(
     actions: Dict[str, Dict],
+    *,
     height: int = DEFAULT_BUTTON_HEIGHT,
     margin: Tuple[int, int] = DEFAULT_TOOLBAR_MARGIN,
     gap: int = DEFAULT_BUTTON_GAP,
     align: str = "left",
     width_provider: Optional[Callable[[], int]] = None,
+    primary_labels: Optional[Tuple[str, ...]] = ("Undo", "Auto"),
 ) -> Toolbar:
-    """
-    actions = {
-      "New": {"on_click": fn, "enabled": fn_opt, "tooltip": str_opt},
-      ...
-    }
-    """
-    btns: List[Button] = []
+    """Create a toolbar that collapses secondary actions into a menu."""
+
+    menu_items: List[MenuItem] = []
+    direct_buttons: List[Button] = []
+    menu_button_tooltip: Optional[str] = None
+    visible_labels = set(primary_labels or ())
+
     for label, cfg in actions.items():
-        btns.append(
-            Button(
-                label=label,
-                on_click=cfg["on_click"],
-                enabled_fn=cfg.get("enabled"),
-                tooltip=cfg.get("tooltip"),
+        on_click = cfg.get("on_click")
+        if not callable(on_click):
+            continue
+        enabled = cfg.get("enabled")
+        tooltip = cfg.get("tooltip")
+        if label in visible_labels:
+            direct_buttons.append(
+                Button(
+                    label=label,
+                    on_click=on_click,
+                    enabled_fn=enabled,
+                    tooltip=tooltip,
+                    height=height,
+                )
+            )
+        else:
+            if label.lower() == "menu" and tooltip:
+                menu_button_tooltip = tooltip
+            menu_items.append(MenuItem(label=label, on_click=on_click, enabled=enabled, tooltip=tooltip))
+
+    buttons: List[Button] = []
+    if menu_items:
+        buttons.append(
+            HamburgerMenuButton(
+                menu_items,
                 height=height,
+                tooltip=menu_button_tooltip,
             )
         )
-    return Toolbar(btns, margin=margin, gap=gap, align=align, width_provider=width_provider)
+    buttons.extend(direct_buttons)
+
+    return Toolbar(buttons, margin=margin, gap=gap, align=align, width_provider=width_provider)
 
 
 class ModalHelp:

--- a/tests/unit_tests/test_app_flow.py
+++ b/tests/unit_tests/test_app_flow.py
@@ -302,7 +302,13 @@ def test_application_flow(monkeypatch, mode):
             if getattr(button, "label", "") == "Menu":
                 rect = getattr(button, "rect", None)
                 assert rect is not None, "Menu button missing rect"
-                return _click_pos(rect.center)
+                events = _click_pos(rect.center)
+                getter = getattr(button, "get_menu_item_rect", None)
+                if callable(getter):
+                    item_rect = getter("Menu")
+                    if item_rect is not None:
+                        events.extend(_click_pos(item_rect.center))
+                return events
         raise AssertionError("Menu button not found on toolbar")
 
     def _click_menu_entry():


### PR DESCRIPTION
## Summary
- add a hamburger menu button component so menu, new, restart, help, save, etc. collapse into a dropdown while leaving undo/auto exposed
- update the shared toolbar factory to build the hamburger control and expose menu item geometry for automation
- adjust the application flow test to open the hamburger menu before selecting the Menu action

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf02279b0c8321991ebb4837455c4b