### PR TITLE
Refine bowling scoring logic

### DIFF
--- a/src/solitaire/modes/bowling_scoring.py
+++ b/src/solitaire/modes/bowling_scoring.py
@@ -1,0 +1,66 @@
+"""Scoring helpers for Bowling Solitaire."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+
+def calculate_frame_totals(rolls: Sequence[int]) -> List[Optional[int]]:
+    """Return cumulative frame totals following ten-pin bowling rules."""
+
+    totals: List[Optional[int]] = [None] * 10
+    cumulative = 0
+    roll_index = 0
+
+    for frame_index in range(10):
+        if roll_index >= len(rolls):
+            break
+
+        first = rolls[roll_index]
+
+        if frame_index < 9:
+            if first == 10:
+                if roll_index + 2 >= len(rolls):
+                    break
+                cumulative += 10 + rolls[roll_index + 1] + rolls[roll_index + 2]
+                totals[frame_index] = cumulative
+                roll_index += 1
+                continue
+
+            if roll_index + 1 >= len(rolls):
+                break
+
+            second = rolls[roll_index + 1]
+            if first + second == 10:
+                if roll_index + 2 >= len(rolls):
+                    break
+                cumulative += 10 + rolls[roll_index + 2]
+            else:
+                cumulative += first + second
+
+            totals[frame_index] = cumulative
+            roll_index += 2
+            continue
+
+        if roll_index + 1 >= len(rolls):
+            break
+
+        second = rolls[roll_index + 1]
+        if first == 10:
+            if roll_index + 2 >= len(rolls):
+                break
+            third = rolls[roll_index + 2]
+            cumulative += 10 + second + third
+        elif first + second == 10:
+            if roll_index + 2 >= len(rolls):
+                break
+            third = rolls[roll_index + 2]
+            cumulative += 10 + third
+        else:
+            cumulative += first + second
+
+        totals[frame_index] = cumulative
+        break
+
+    return totals
+

--- a/src/solitaire/modes/bowling_solitaire.py
+++ b/src/solitaire/modes/bowling_solitaire.py
@@ -16,6 +16,7 @@ from solitaire import common as C
 from solitaire import ui as UI
 from solitaire.help_data import create_modal_help
 from solitaire.modes.base_scene import ModeUIHelper
+from .bowling_scoring import calculate_frame_totals
 
 
 # --- Save helpers -----------------------------------------------------------
@@ -1024,58 +1025,9 @@ class BowlingSolitaireGameScene(C.Scene):
                     frame.symbols[2] = "X" if knocked == 10 else (str(knocked) if knocked > 0 else "-")
 
     def _recompute_totals(self) -> None:
-        cumulative = 0
-        rolls = self.roll_history
-        idx = 0
-        for frame_index in range(10):
-            frame = self.score_frames[frame_index]
-            frame.total = None
-            if frame_index < 9:
-                if idx >= len(rolls):
-                    break
-                first = rolls[idx]
-                if first == 10:
-                    if idx + 2 < len(rolls):
-                        cumulative += 10 + rolls[idx + 1] + rolls[idx + 2]
-                        frame.total = cumulative
-                    idx += 1
-                else:
-                    if idx + 1 >= len(rolls):
-                        break
-                    second = rolls[idx + 1]
-                    if first + second == 10:
-                        if idx + 2 < len(rolls):
-                            cumulative += 10 + rolls[idx + 2]
-                            frame.total = cumulative
-                    else:
-                        cumulative += first + second
-                        frame.total = cumulative
-                    idx += 2
-            else:
-                if idx >= len(rolls):
-                    break
-                first = rolls[idx]
-                if idx + 1 >= len(rolls):
-                    break
-                second = rolls[idx + 1]
-                if first == 10:
-                    if idx + 2 >= len(rolls):
-                        break
-                    third = rolls[idx + 2]
-                    cumulative += 10 + second + third
-                    frame.total = cumulative
-                    idx += 3
-                elif first + second == 10:
-                    if idx + 2 >= len(rolls):
-                        break
-                    third = rolls[idx + 2]
-                    cumulative += 10 + third
-                    frame.total = cumulative
-                    idx += 3
-                else:
-                    cumulative += first + second
-                    frame.total = cumulative
-                    idx += 2
+        totals = calculate_frame_totals(self.roll_history)
+        for frame, total in zip(self.score_frames, totals):
+            frame.total = total
 
     # ------------------------------------------------------------------- saving
 

--- a/tests/unit_tests/test_bowling_scoring.py
+++ b/tests/unit_tests/test_bowling_scoring.py
@@ -1,0 +1,44 @@
+from typing import List, Optional
+
+import pytest
+
+from solitaire.modes.bowling_scoring import calculate_frame_totals
+
+
+@pytest.mark.parametrize(
+    "rolls, expected",
+    [
+        ([10] * 12, [30, 60, 90, 120, 150, 180, 210, 240, 270, 300]),
+        (
+            [9, 1] * 9 + [9, 1, 9],
+            [19, 38, 57, 76, 95, 114, 133, 152, 171, 190],
+        ),
+        (
+            [0, 0] * 9 + [10, 10, 10],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 30],
+        ),
+        (
+            [0, 0] * 8 + [7, 3] + [10, 10, 10],
+            [0, 0, 0, 0, 0, 0, 0, 0, 20, 50],
+        ),
+        (
+            [7, 3, 5, 4] + [0, 0] * 8,
+            [15, 24, 24, 24, 24, 24, 24, 24, 24, 24],
+        ),
+        (
+            [10, 7, 3, 7, 2] + [0, 0] * 7,
+            [20, 37, 46, 46, 46, 46, 46, 46, 46, 46],
+        ),
+    ],
+)
+def test_calculate_frame_totals_complete_games(
+    rolls: List[int], expected: List[Optional[int]]
+) -> None:
+    assert calculate_frame_totals(rolls) == expected
+
+
+def test_calculate_frame_totals_requires_future_rolls() -> None:
+    totals = calculate_frame_totals([10, 3])
+    assert totals[0] is None
+    assert all(total is None for total in totals[1:])
+


### PR DESCRIPTION
## Summary
- extract bowling frame scoring rules into a dedicated helper that follows ten-pin strike and spare calculations
- have the Bowling Solitaire scene reuse the helper when recomputing scoreboard totals
- add unit tests that cover strikes, spares, tenth-frame bonuses, and partial games

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ae3291148321a852afca7550a9c1