### PR TITLE
Ensure drag pan works in every solitaire mode

### DIFF
--- a/src/solitaire/modes/accordion.py
+++ b/src/solitaire/modes/accordion.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 import pygame
 
 from solitaire import common as C
+from solitaire import mechanics as M
 from solitaire.help_data import create_modal_help
 from solitaire.modes.base_scene import ModeUIHelper
 
@@ -123,6 +124,7 @@ class AccordionGameScene(C.Scene):
         self.piles: List[C.Pile] = []
         self.scroll_y: int = 0
         self._min_scroll_y: int = 0
+        self.drag_pan = M.DragPanController()
         self.undo_mgr = C.UndoManager()
         self.undo_after_deal_allowed: bool = self.difficulty == "easy"
         self.drag_info: Optional[Dict[str, Any]] = None
@@ -441,6 +443,9 @@ class AccordionGameScene(C.Scene):
         if self.toolbar.handle_event(event):
             return
         if self.ui_helper.handle_shortcuts(event):
+            return
+
+        if self.drag_pan.handle_event(event, target=self, clamp=self._clamp_scroll, attr_x=None):
             return
 
         if event.type == pygame.MOUSEWHEEL:

--- a/src/solitaire/modes/beleaguered_castle.py
+++ b/src/solitaire/modes/beleaguered_castle.py
@@ -62,6 +62,7 @@ class BeleagueredCastleGameScene(C.Scene):
         self._auto_active = False
         self.scroll_x = 0
         self.scroll_y = 0
+        self.drag_pan = M.DragPanController()
         self._drag_vscroll = False
         self._drag_hscroll = False
         self._vscroll_geom = None
@@ -523,6 +524,9 @@ class BeleagueredCastleGameScene(C.Scene):
             return
 
         if self.anim.active:
+            return
+
+        if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll_xy):
             return
 
         if e.type == pygame.MOUSEWHEEL:

--- a/src/solitaire/modes/big_ben.py
+++ b/src/solitaire/modes/big_ben.py
@@ -105,6 +105,7 @@ class BigBenGameScene(C.Scene):
         self._center = (0, 0)
         self.scroll_x = 0
         self.scroll_y = 0
+        self.drag_pan = M.DragPanController()
         self._drag_vscroll = False
         self._drag_hscroll = False
         self._vscroll_geom = None
@@ -596,6 +597,10 @@ class BigBenGameScene(C.Scene):
                 return
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN):
                 return
+
+        if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll_xy):
+            self.peek.cancel()
+            return
 
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             self.peek.cancel()

--- a/src/solitaire/modes/bowling_solitaire.py
+++ b/src/solitaire/modes/bowling_solitaire.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Seque
 import pygame
 
 from solitaire import common as C
+from solitaire import mechanics as M
 from solitaire import ui as UI
 from solitaire.help_data import create_modal_help
 from solitaire.modes.base_scene import ModeUIHelper
@@ -236,6 +237,7 @@ class BowlingSolitaireGameScene(C.Scene):
 
         self.scroll_x: int = 0
         self.scroll_y: int = 0
+        self.drag_pan = M.DragPanController()
         self._drag_vscroll: bool = False
         self._drag_hscroll: bool = False
         self._vscroll_drag_offset: int = 0
@@ -1434,6 +1436,8 @@ class BowlingSolitaireGameScene(C.Scene):
         if self.toolbar and self.toolbar.handle_event(event):
             return
         if self.ui_helper.handle_shortcuts(event):
+            return
+        if self.drag_pan.handle_event(event, target=self, clamp=self._clamp_scroll):
             return
         if self._handle_scroll_event(event):
             return

--- a/src/solitaire/modes/freecell.py
+++ b/src/solitaire/modes/freecell.py
@@ -25,6 +25,7 @@ class FreeCellGameScene(C.Scene):
         self._drag_hscroll = False
         self._hscroll_drag_dx = 0
         self._hscroll_geom = None
+        self.drag_pan = M.DragPanController()
 
         # Piles
         self.freecells: List[C.Pile] = [C.Pile(0, 0) for _ in range(4)]
@@ -308,6 +309,10 @@ class FreeCellGameScene(C.Scene):
         if self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
+            return
+
+        if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll_xy):
+            self.peek.cancel()
             return
 
         if e.type == pygame.MOUSEWHEEL:

--- a/src/solitaire/modes/gate.py
+++ b/src/solitaire/modes/gate.py
@@ -81,6 +81,7 @@ class GateGameScene(C.Scene):
         self._auto_complete_active = False
         # Vertical scrolling
         self.scroll_y = 0
+        self.drag_pan = M.DragPanController()
         self._drag_vscroll = False
         self._vscroll_drag_dy = 0
         self._vscroll_geom: Optional[Tuple[int, int, int, int, int]] = None
@@ -446,6 +447,10 @@ class GateGameScene(C.Scene):
 
         # Update dynamic fan spacing for center piles
         self._update_center_fans()
+
+        if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll, attr_x=None):
+            self.peek.cancel()
+            return
 
         # Mouse wheel vertical scroll
         if e.type == pygame.MOUSEWHEEL:

--- a/src/solitaire/modes/golf.py
+++ b/src/solitaire/modes/golf.py
@@ -5,6 +5,7 @@ import pygame
 from typing import List, Optional, Tuple, Dict, Any
 
 from solitaire import common as C
+from solitaire import mechanics as M
 from solitaire.modes.base_scene import ModeUIHelper
 from solitaire.help_data import create_modal_help
 
@@ -144,6 +145,7 @@ class GolfGameScene(C.Scene):
         # Scrolling (vertical + horizontal)
         self.scroll_y: int = 0
         self.scroll_x: int = 0
+        self.drag_pan = M.DragPanController()
         self._drag_vscroll: bool = False
         self._drag_hscroll: bool = False
         # Last drawn geometry for scrollbar calculations
@@ -523,6 +525,8 @@ class GolfGameScene(C.Scene):
         if self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
+            return
+        if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll):
             return
         # Scroll wheel for content
         if e.type == pygame.MOUSEWHEEL:

--- a/src/solitaire/modes/klondike.py
+++ b/src/solitaire/modes/klondike.py
@@ -16,9 +16,7 @@ class KlondikeGameScene(C.Scene):
         # 2D scroll for large cards
         self.scroll_x = 0
         self.scroll_y = 0
-        self._panning = False
-        self._pan_anchor = (0, 0)
-        self._scroll_anchor = (0, 0)
+        self.drag_pan = M.DragPanController()
         self._drag_vscroll = False
         self._drag_hscroll = False
         self.draw_count = draw_count
@@ -386,6 +384,10 @@ class KlondikeGameScene(C.Scene):
         if self.ui_helper.handle_shortcuts(e):
             return
 
+        if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll_xy):
+            self.peek.cancel()
+            return
+
         # Mouse wheel scrolling (supports trackpads: e.x horizontal, e.y vertical)
         if e.type == pygame.MOUSEWHEEL:
             self.scroll_y += e.y * 60  # up is positive
@@ -500,25 +502,6 @@ class KlondikeGameScene(C.Scene):
                 if hi != -1 and t.cards[hi].face_up:
                     seq = t.cards[hi:]; t.cards = t.cards[:hi]
                     self.drag_stack = (seq, ("tableau", ti)); self.edge_pan.set_active(True); return
-
-        # Middle-button drag panning
-        if e.type == pygame.MOUSEBUTTONDOWN and e.button == 2:
-            self._panning = True
-            self._pan_anchor = e.pos
-            self._scroll_anchor = (self.scroll_x, self.scroll_y)
-            return
-        elif e.type == pygame.MOUSEBUTTONUP and e.button == 2:
-            self._panning = False
-            return
-        elif e.type == pygame.MOUSEMOTION and self._panning:
-            mx, my = e.pos
-            ax, ay = self._pan_anchor
-            dx = mx - ax
-            dy = my - ay
-            self.scroll_x = self._scroll_anchor[0] + dx
-            self.scroll_y = self._scroll_anchor[1] + dy
-            self._clamp_scroll_xy()
-            return
 
         elif e.type == pygame.MOUSEBUTTONUP and e.button == 1:
             if not self.drag_stack: return

--- a/src/solitaire/modes/tripeaks.py
+++ b/src/solitaire/modes/tripeaks.py
@@ -14,6 +14,7 @@ Rules (implemented):
 from typing import List, Optional, Tuple
 import pygame
 from solitaire import common as C
+from solitaire import mechanics as M
 from solitaire.modes.base_scene import ModeUIHelper
 from solitaire.help_data import create_modal_help
 
@@ -76,9 +77,7 @@ class TriPeaksGameScene(C.Scene):
         self.scroll_y: int = 0
         self._drag_vscroll = False
         self._drag_hscroll = False
-        self._panning = False
-        self._pan_anchor = (0, 0)
-        self._scroll_anchor = (0, 0)
+        self.drag_pan = M.DragPanController()
 
         # Tableau rows: sizes [3, 6, 9, 10]
         self.rows: List[List[Optional[C.Card]]] = []
@@ -507,6 +506,9 @@ class TriPeaksGameScene(C.Scene):
         if hasattr(self, "toolbar") and self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
+            return
+
+        if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll):
             return
 
         # Mouse wheel scrolling

--- a/src/solitaire/modes/yukon.py
+++ b/src/solitaire/modes/yukon.py
@@ -122,6 +122,7 @@ class YukonGameScene(C.Scene):
         # Scrolling (both axes)
         self.scroll_x = 0
         self.scroll_y = 0
+        self.drag_pan = M.DragPanController()
         self._drag_vscroll = False
         self._drag_hscroll = False
         self._vscroll_geom = None
@@ -396,6 +397,10 @@ class YukonGameScene(C.Scene):
         if self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
+            return
+
+        if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll_xy):
+            self.peek.cancel()
             return
 
         # Do not interact while animation is running


### PR DESCRIPTION
## Summary
- add a reusable DragPanController in mechanics for middle-mouse panning
- wire the controller into every scrollable game mode so dragging pans consistently
- replace bespoke panning code in Klondike and Pyramid with the shared helper

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d8e3be31008321b11c196c71927f89