### PR TITLE
Extend drag edge panning to scrollable packer modes

### DIFF
--- a/src/solitaire/modes/accordion.py
+++ b/src/solitaire/modes/accordion.py
@@ -125,6 +125,10 @@ class AccordionGameScene(C.Scene):
         self.scroll_y: int = 0
         self._min_scroll_y: int = 0
         self.drag_pan = M.DragPanController()
+        self.edge_pan = M.EdgePanDuringDrag(
+            edge_margin_px=28,
+            top_inset_px=getattr(C, "TOP_BAR_H", 60),
+        )
         self.undo_mgr = C.UndoManager()
         self.undo_after_deal_allowed: bool = self.difficulty == "easy"
         self.drag_info: Optional[Dict[str, Any]] = None
@@ -194,6 +198,7 @@ class AccordionGameScene(C.Scene):
         self.undo_mgr = C.UndoManager()
         self.drag_info = None
         self._update_layout()
+        self.edge_pan.set_active(False)
         delete_saved_game()
 
     def _save_and_exit(self) -> None:
@@ -216,6 +221,7 @@ class AccordionGameScene(C.Scene):
         self.undo_mgr = C.UndoManager()
         self.undo_after_deal_allowed = self.difficulty == "easy"
         self.drag_info = None
+        self.edge_pan.set_active(False)
         self.message = ""
         self.game_over = False
         self.did_win = False
@@ -294,6 +300,7 @@ class AccordionGameScene(C.Scene):
             else:
                 self.undo_after_deal_allowed = bool(snapshot.get("undo_after_deal", False))
             self.drag_info = None
+            self.edge_pan.set_active(False)
             self._update_layout()
 
         self.undo_mgr.push(undo_snapshot)
@@ -375,6 +382,7 @@ class AccordionGameScene(C.Scene):
             "pos": (rect.x, rect.y),
             "cards": list(pile.cards),
         }
+        self.edge_pan.set_active(True)
 
     def _update_drag(self, mouse_pos: Tuple[int, int]) -> None:
         if not self.drag_info:
@@ -389,6 +397,7 @@ class AccordionGameScene(C.Scene):
             return
         src_index = self.drag_info.get("index")
         self.drag_info = None
+        self.edge_pan.set_active(False)
         if src_index is None or src_index < 0 or src_index >= len(self.piles):
             return
         world_pos = self._world_pos(mouse_pos)
@@ -428,6 +437,9 @@ class AccordionGameScene(C.Scene):
 
     # ----- Event handling ------------------------------------------------------
     def handle_event(self, event) -> None:
+        if event.type == pygame.MOUSEMOTION:
+            self.edge_pan.on_mouse_pos(event.pos)
+
         if getattr(self, "help", None) and self.help.visible:
             if self.help.handle_event(event):
                 return
@@ -476,6 +488,14 @@ class AccordionGameScene(C.Scene):
     # ----- Draw ----------------------------------------------------------------
     def draw(self, screen) -> None:
         screen.fill(C.TABLE_BG)
+
+        # Edge panning while dragging near screen edges
+        self.edge_pan.on_mouse_pos(pygame.mouse.get_pos())
+        has_v_scroll = self._min_scroll_y < 0
+        _, dy = self.edge_pan.step(has_h_scroll=False, has_v_scroll=has_v_scroll)
+        if dy:
+            self.scroll_y += dy
+            self._clamp_scroll()
 
         prev_offset_y = C.DRAW_OFFSET_Y
         C.DRAW_OFFSET_Y = self.scroll_y

--- a/src/solitaire/modes/demon.py
+++ b/src/solitaire/modes/demon.py
@@ -210,6 +210,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
         self.waste_pile.cards.clear()
         self.drag = None
         self.message = ""
+        self.edge_pan.set_active(False)
 
     def deal_new(self) -> None:
         cfg = load_demon_config()
@@ -292,6 +293,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
         self.message = snap.get("message", "")
         self.drag = None
         self.reset_scroll()
+        self.edge_pan.set_active(False)
 
     def push_undo(self) -> None:
         snap = self.record_snapshot()
@@ -302,6 +304,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
             self.undo_mgr.undo()
             self.message = ""
             self.drag = None
+            self.edge_pan.set_active(False)
 
     # ----- Save / Load helpers -----
     def _state_dict(self) -> Dict:
@@ -319,6 +322,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
     def _load_from_state(self, state: Dict) -> None:
         self.restore_snapshot(state)
         self.drag = None
+        self.edge_pan.set_active(False)
 
     # ----- Gameplay helpers -----
     def is_completed(self) -> bool:
@@ -473,6 +477,9 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
         return False
 
     def handle_event(self, event) -> None:
+        if event.type == pygame.MOUSEMOTION:
+            self.edge_pan.on_mouse_pos(event.pos)
+
         if self.help.visible:
             if self.help.handle_event(event):
                 return
@@ -513,6 +520,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
                 rect = self.waste_pile.rect_for_index(waste_idx)
                 card = self.waste_pile.cards.pop()
                 self.drag = _DragState([card], ("waste", None), (mxw - rect.x, myw - rect.y), event.pos)
+                self.edge_pan.set_active(True)
                 return
 
             reserve_idx = self.reserve.hit((mxw, myw))
@@ -520,6 +528,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
                 rect = self.reserve.rect_for_index(reserve_idx)
                 card = self.reserve.cards.pop()
                 self.drag = _DragState([card], ("reserve", None), (mxw - rect.x, myw - rect.y), event.pos)
+                self.edge_pan.set_active(True)
                 return
 
             for ti, pile in enumerate(self.tableau):
@@ -534,6 +543,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
                 rect = pile.rect_for_index(hit)
                 pile.cards = pile.cards[:hit]
                 self.drag = _DragState(seq, ("tableau", ti), (mxw - rect.x, myw - rect.y), event.pos)
+                self.edge_pan.set_active(True)
                 return
 
         elif event.type == pygame.MOUSEMOTION:
@@ -545,6 +555,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
                 return
             drag = self.drag
             self.drag = None
+            self.edge_pan.set_active(False)
             stack = drag.cards
             origin, idx = drag.origin
             mxw, myw = self._screen_to_world(event.pos)

--- a/src/solitaire/modes/duchess.py
+++ b/src/solitaire/modes/duchess.py
@@ -185,6 +185,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
         self.waste_pile.cards.clear()
         self.drag = None
         self.message = ""
+        self.edge_pan.set_active(False)
 
     def deal_new(self) -> None:
         self._clear()
@@ -271,6 +272,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
         self.message = snap.get("message", "")
         self.drag = None
         self.reset_scroll()
+        self.edge_pan.set_active(False)
 
     def push_undo(self) -> None:
         snap = self.record_snapshot()
@@ -281,6 +283,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
             self.undo_mgr.undo()
             self.message = ""
             self.drag = None
+            self.edge_pan.set_active(False)
 
     # ----- Save / Load helpers -----
     def _state_dict(self) -> Dict:
@@ -298,6 +301,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
     def _load_from_state(self, state: Dict) -> None:
         self.restore_snapshot(state)
         self.drag = None
+        self.edge_pan.set_active(False)
 
     # ----- Gameplay helpers -----
     def is_completed(self) -> bool:
@@ -488,6 +492,9 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
         self.post_move_cleanup()
 
     def handle_event(self, event) -> None:
+        if event.type == pygame.MOUSEMOTION:
+            self.edge_pan.on_mouse_pos(event.pos)
+
         if self.help.visible:
             if self.help.handle_event(event):
                 return
@@ -528,6 +535,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
                 rect = self.waste_pile.rect_for_index(waste_idx)
                 card = self.waste_pile.cards.pop()
                 self.drag = _DragState([card], ("waste", None), (mxw - rect.x, myw - rect.y), event.pos)
+                self.edge_pan.set_active(True)
                 return
 
             for ri, pile in enumerate(self.reserves):
@@ -541,6 +549,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
                 rect = pile.rect_for_index(hit)
                 card = pile.cards.pop()
                 self.drag = _DragState([card], ("reserve", ri), (mxw - rect.x, myw - rect.y), event.pos)
+                self.edge_pan.set_active(True)
                 return
 
             for ti, pile in enumerate(self.tableau):
@@ -555,6 +564,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
                 rect = pile.rect_for_index(hit)
                 pile.cards = pile.cards[:hit]
                 self.drag = _DragState(seq, ("tableau", ti), (mxw - rect.x, myw - rect.y), event.pos)
+                self.edge_pan.set_active(True)
                 return
 
         elif event.type == pygame.MOUSEMOTION:
@@ -566,6 +576,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
                 return
             drag = self.drag
             self.drag = None
+            self.edge_pan.set_active(False)
             stack = drag.cards
             origin, idx = drag.origin
             mxw, myw = self._screen_to_world(event.pos)


### PR DESCRIPTION
## Summary
- add shared edge-panning support to ScrollableSceneMixin so scrollable modes auto-scroll while dragging near the viewport edges
- update Demon, Duchess, and Chameleon drag handling to activate/deactivate the shared controller and reset it on state changes

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d972d1accc8321957d3341e462da43