### PR TITLE
Refactor game selection into modal

### DIFF
--- a/src/solitaire/scenes/menu.py
+++ b/src/solitaire/scenes/menu.py
@@ -1,9 +1,17 @@
 ﻿# menu.py - Main menu
 import os
-import pygame
 from math import ceil
+
+import pygame
+
 from solitaire import common as C
 from solitaire.modes.base_scene import GAME_REGISTRY, GAME_SECTIONS, GameMetadata
+from solitaire.scenes.menu_options import (
+    CONTROLLER_REGISTRY,
+    ButtonState,
+    GameOptionsController,
+    OptionState,
+)
 
 
 class _GameEntry:
@@ -33,6 +41,278 @@ class _GameEntry:
         self.label_rect = pygame.Rect(0, 0, 0, 0)
 
 
+class _OptionRowLayout:
+    __slots__ = ("key", "label_pos", "value_rect", "left_rect", "right_rect")
+
+    def __init__(self, key: str, label_pos, value_rect, left_rect, right_rect) -> None:
+        self.key = key
+        self.label_pos = label_pos
+        self.value_rect = value_rect
+        self.left_rect = left_rect
+        self.right_rect = right_rect
+
+
+class _ActionLayout:
+    __slots__ = ("key", "rect")
+
+    def __init__(self, key: str, rect: pygame.Rect) -> None:
+        self.key = key
+        self.rect = rect
+
+
+class GameOptionsModal:
+    WIDTH = 680
+    PADDING_X = 48
+    PADDING_TOP = 96
+    OPTION_GAP = 32
+    OPTION_HEIGHT = 56
+    OPTION_ARROW = 48
+    OPTION_ARROW_GAP = 16
+    MESSAGE_HEIGHT = 32
+    BUTTON_HEIGHT = 56
+    BUTTON_GAP = 20
+    BOTTOM_PADDING = 70
+
+    def __init__(self, scene: "MainMenuScene", controller: GameOptionsController) -> None:
+        self.scene = scene
+        self.controller = controller
+        self.rect = pygame.Rect(0, 0, self.WIDTH, 400)
+        self.rect.center = (C.SCREEN_W // 2, C.SCREEN_H // 2)
+        self._options_layout: list[_OptionRowLayout] = []
+        self._actions_layout: list[_ActionLayout] = []
+        self._option_signature: tuple[str, ...] = ()
+        self._button_signature: tuple[str, ...] = ()
+        self._message_rect = pygame.Rect(0, 0, 0, 0)
+        self._title_pos = (0, 0)
+        self._reflow()
+
+    # ----- layout ----------------------------------------------------
+    def _option_rows(self) -> list[OptionState]:
+        return list(self.controller.options())
+
+    def _button_rows(self) -> list[ButtonState]:
+        return list(self.controller.buttons())
+
+    def _reflow(self) -> None:
+        options = self._option_rows()
+        buttons = self._button_rows()
+        option_keys = tuple(opt.key for opt in options)
+        button_keys = tuple(btn.key for btn in buttons)
+        if option_keys == self._option_signature and button_keys == self._button_signature:
+            return
+        self._option_signature = option_keys
+        self._button_signature = button_keys
+
+        label_font = C.FONT_UI or pygame.font.SysFont(pygame.font.get_default_font(), 26, bold=True)
+        label_height = label_font.get_height()
+
+        current_y = self.PADDING_TOP
+        relative_rows = []
+        for opt in options:
+            label_y = current_y
+            current_y += label_height + 10
+            value_y = current_y
+            current_y += self.OPTION_HEIGHT + self.OPTION_GAP
+            relative_rows.append((opt.key, label_y, value_y))
+
+        message_top = current_y
+        action_top = message_top + self.MESSAGE_HEIGHT + 10
+        total_height = action_top + self.BUTTON_HEIGHT + self.BOTTOM_PADDING
+        self.rect = pygame.Rect(0, 0, self.WIDTH, total_height)
+        self.rect.center = (C.SCREEN_W // 2, C.SCREEN_H // 2)
+        self._title_pos = (self.rect.centerx, self.rect.y + 46)
+
+        self._options_layout = []
+        value_width = self.rect.width - 2 * self.PADDING_X - 2 * (self.OPTION_ARROW + self.OPTION_ARROW_GAP)
+        for key, label_y, value_y in relative_rows:
+            label_pos = (self.rect.x + self.PADDING_X, self.rect.y + label_y)
+            value_rect = pygame.Rect(
+                self.rect.x + self.PADDING_X + self.OPTION_ARROW + self.OPTION_ARROW_GAP,
+                self.rect.y + value_y,
+                value_width,
+                self.OPTION_HEIGHT,
+            )
+            left_rect = pygame.Rect(
+                value_rect.left - self.OPTION_ARROW - self.OPTION_ARROW_GAP,
+                value_rect.y,
+                self.OPTION_ARROW,
+                self.OPTION_HEIGHT,
+            )
+            right_rect = pygame.Rect(
+                value_rect.right + self.OPTION_ARROW_GAP,
+                value_rect.y,
+                self.OPTION_ARROW,
+                self.OPTION_HEIGHT,
+            )
+            self._options_layout.append(_OptionRowLayout(key, label_pos, value_rect, left_rect, right_rect))
+
+        self._message_rect = pygame.Rect(
+            self.rect.x + self.PADDING_X,
+            self.rect.y + message_top,
+            self.rect.width - 2 * self.PADDING_X,
+            self.MESSAGE_HEIGHT,
+        )
+
+        actions = []
+        if buttons:
+            available_width = self.rect.width - 2 * self.PADDING_X
+            btn_count = len(buttons)
+            button_width = min(200, max(120, (available_width - self.BUTTON_GAP * (btn_count - 1)) // btn_count))
+            total_width = button_width * btn_count + self.BUTTON_GAP * (btn_count - 1)
+            start_x = self.rect.x + self.PADDING_X + (available_width - total_width) // 2
+            button_y = self.rect.y + action_top
+            for index, btn in enumerate(buttons):
+                rect = pygame.Rect(start_x + index * (button_width + self.BUTTON_GAP), button_y, button_width, self.BUTTON_HEIGHT)
+                actions.append(_ActionLayout(btn.key, rect))
+        self._actions_layout = actions
+
+    # ----- event handling -------------------------------------------
+    def handle_event(self, event) -> bool:
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if not self.rect.collidepoint(event.pos):
+                return True
+            option_map = {opt.key: opt for opt in self._option_rows()}
+            for layout in self._options_layout:
+                opt = option_map.get(layout.key)
+                if opt is None or len(opt.values) <= 1:
+                    continue
+                if layout.left_rect.collidepoint(event.pos):
+                    self.controller.change_option(layout.key, -1)
+                    self._reflow()
+                    return False
+                if layout.right_rect.collidepoint(event.pos):
+                    self.controller.change_option(layout.key, 1)
+                    self._reflow()
+                    return False
+            button_states = {btn.key: btn for btn in self._button_rows()}
+            for layout in self._actions_layout:
+                state = button_states.get(layout.key)
+                if state is None:
+                    continue
+                if not state.enabled:
+                    continue
+                if layout.rect.collidepoint(event.pos):
+                    result = self.controller.handle_button(layout.key)
+                    self._reflow()
+                    return result.close_modal
+        return False
+
+    def get_action_rect(self, key: str) -> pygame.Rect | None:
+        for layout in self._actions_layout:
+            if layout.key == key:
+                return layout.rect.copy()
+        return None
+
+    # ----- drawing --------------------------------------------------
+    def _draw_arrow_button(self, screen, rect: pygame.Rect, direction: str, enabled: bool, hover: bool) -> None:
+        base = (200, 200, 205)
+        hover_col = (230, 210, 120)
+        disabled = (160, 160, 160)
+        color = disabled if not enabled else (hover_col if hover else base)
+        pygame.draw.rect(screen, color, rect, border_radius=rect.height // 2)
+        border_col = (80, 80, 85)
+        pygame.draw.rect(screen, border_col, rect, width=2, border_radius=rect.height // 2)
+        cx = rect.centerx
+        cy = rect.centery
+        size = rect.height // 3
+        if direction == "left":
+            points = [(cx + size // 2, cy - size), (cx - size, cy), (cx + size // 2, cy + size)]
+        else:
+            points = [(cx - size // 2, cy - size), (cx + size, cy), (cx - size // 2, cy + size)]
+        pygame.draw.polygon(screen, border_col if enabled else (110, 110, 110), points)
+
+    def _draw_value_box(self, screen, rect: pygame.Rect, text: str) -> None:
+        pygame.draw.rect(screen, (245, 245, 245), rect, border_radius=rect.height // 2)
+        pygame.draw.rect(screen, (90, 90, 90), rect, width=2, border_radius=rect.height // 2)
+        font = C.FONT_UI or pygame.font.SysFont(pygame.font.get_default_font(), 26, bold=True)
+        surf = font.render(text, True, (40, 40, 45))
+        screen.blit(surf, (rect.centerx - surf.get_width() // 2, rect.centery - surf.get_height() // 2))
+
+    def _draw_action_button(self, screen, rect: pygame.Rect, state: ButtonState, hover: bool) -> None:
+        if state.variant == "primary":
+            base = (230, 200, 90)
+            hover_col = (240, 210, 110)
+        elif state.variant == "cancel":
+            base = (210, 210, 210)
+            hover_col = (230, 230, 230)
+        else:
+            base = (210, 210, 210)
+            hover_col = (225, 225, 225)
+        disabled = (170, 170, 170)
+        color = disabled if not state.enabled else (hover_col if hover else base)
+        pygame.draw.rect(screen, color, rect, border_radius=18)
+        pygame.draw.rect(screen, (60, 60, 65), rect, width=2, border_radius=18)
+        font = C.FONT_UI or pygame.font.SysFont(pygame.font.get_default_font(), 24, bold=True)
+        text_color = (40, 40, 40)
+        surf = font.render(state.label, True, text_color)
+        screen.blit(surf, (rect.centerx - surf.get_width() // 2, rect.centery - surf.get_height() // 2))
+
+    def draw(self, screen) -> None:
+        self.controller.refresh()
+        self._reflow()
+
+        overlay = pygame.Surface((C.SCREEN_W, C.SCREEN_H), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 140))
+        screen.blit(overlay, (0, 0))
+
+        pygame.draw.rect(screen, (250, 250, 250), self.rect, border_radius=28)
+        pygame.draw.rect(screen, (70, 70, 70), self.rect, width=2, border_radius=28)
+
+        title_font = C.FONT_TITLE or pygame.font.SysFont(pygame.font.get_default_font(), 42, bold=True)
+        title_text = self.controller.title()
+        title_surf = title_font.render(title_text, True, (40, 40, 45))
+        screen.blit(title_surf, (self._title_pos[0] - title_surf.get_width() // 2, self._title_pos[1]))
+
+        label_font = C.FONT_UI or pygame.font.SysFont(pygame.font.get_default_font(), 26, bold=True)
+        options_map = {opt.key: opt for opt in self._option_rows()}
+        mp = pygame.mouse.get_pos()
+        for layout in self._options_layout:
+            opt = options_map.get(layout.key)
+            if opt is None:
+                continue
+            label_surf = label_font.render(opt.label, True, (60, 60, 65))
+            screen.blit(label_surf, layout.label_pos)
+            value_text = opt.current_text()
+            self._draw_value_box(screen, layout.value_rect, value_text)
+            arrows_enabled = len(opt.values) > 1
+            self._draw_arrow_button(
+                screen,
+                layout.left_rect,
+                "left",
+                arrows_enabled,
+                arrows_enabled and layout.left_rect.collidepoint(mp),
+            )
+            self._draw_arrow_button(
+                screen,
+                layout.right_rect,
+                "right",
+                arrows_enabled,
+                arrows_enabled and layout.right_rect.collidepoint(mp),
+            )
+
+        message = self.controller.message
+        if message:
+            msg_font = C.FONT_SMALL or pygame.font.SysFont(pygame.font.get_default_font(), 20)
+            msg_surf = msg_font.render(message, True, (160, 30, 30))
+            screen.blit(
+                msg_surf,
+                (
+                    self._message_rect.centerx - msg_surf.get_width() // 2,
+                    self._message_rect.centery - msg_surf.get_height() // 2,
+                ),
+            )
+
+        button_states = {btn.key: btn for btn in self._button_rows()}
+        for layout in self._actions_layout:
+            state = button_states.get(layout.key)
+            if state is None:
+                continue
+            hover = state.enabled and layout.rect.collidepoint(mp)
+            self._draw_action_button(screen, layout.rect, state, hover)
+
+
 class MainMenuScene(C.Scene):
     ICON_SIZE = 128
     ICON_GAP = 24
@@ -51,12 +331,15 @@ class MainMenuScene(C.Scene):
     SCROLLBAR_WIDTH = 14
     SCROLL_STEP = 48
 
-    def __init__(self, app):
+    def __init__(self, app, *, open_game_key: str | None = None):
         super().__init__(app)
         self._menu_button_rect = pygame.Rect(0, 0, 56, 40)
         self._menu_margin = (28, 24)
         self._menu_hover = False
         self._modal_open = False
+        self._options_modal: GameOptionsModal | None = None
+        self._options_proxy = None
+        self._pending_open_key = open_game_key
         self._hover_entry: _GameEntry | None = None
 
         icon_dir = os.path.join(os.path.dirname(C.__file__), "assets", "images", "game_icons")
@@ -110,6 +393,9 @@ class MainMenuScene(C.Scene):
 
         self._prepare_assets()
         self.compute_layout()
+        if self._pending_open_key:
+            self._open_game_modal(self._pending_open_key)
+            self._pending_open_key = None
 
     # --- asset helpers -------------------------------------------------
     def _prepare_assets(self):
@@ -286,13 +572,57 @@ class MainMenuScene(C.Scene):
         return rect
 
     # --- interaction ---------------------------------------------------
+    def _open_game_modal(self, game_key: str, *, proxy=None) -> None:
+        entry = self._entry_lookup.get(game_key)
+        if entry is None:
+            return
+        self._open_game_modal_for_entry(entry, proxy=proxy)
+
+    def _open_game_modal_for_entry(self, entry: _GameEntry, *, proxy=None) -> bool:
+        controller_cls = CONTROLLER_REGISTRY.get(entry.key)
+        if controller_cls is None:
+            return False
+        controller = controller_cls(self, metadata=entry.metadata)
+        self._options_modal = GameOptionsModal(self, controller)
+        self._prepare_options_proxy(entry, controller, proxy=proxy)
+        return True
+
+    def _prepare_options_proxy(self, entry: _GameEntry, controller: GameOptionsController, *, proxy=None) -> None:
+        self._options_proxy = None
+        if self._options_modal is None:
+            return
+        if proxy is None:
+            if not entry.scene_cls or not entry.module:
+                return
+            try:
+                module = __import__(entry.module, fromlist=[entry.scene_cls])
+                scene_cls = getattr(module, entry.scene_cls)
+                proxy = scene_cls(self.app)
+            except Exception:
+                return
+        mapping = controller.compatibility_actions()
+        for attr, action_key in mapping.items():
+            btn = getattr(proxy, attr, None)
+            if btn is None:
+                continue
+            rect = self._options_modal.get_action_rect(action_key)
+            if rect is None:
+                continue
+            btn.rect.size = rect.size
+            btn.rect.center = rect.center
+        self._options_proxy = proxy
+
     def _activate_entry(self, entry: _GameEntry):
-        try:
-            module = __import__(entry.module, fromlist=[entry.scene_cls])
-            scene_cls = getattr(module, entry.scene_cls)
-            self.next_scene = scene_cls(self.app)
-        except Exception:
-            pass
+        if self._modal_open:
+            return
+        if not self._open_game_modal_for_entry(entry):
+            try:
+                module = __import__(entry.module, fromlist=[entry.scene_cls])
+                scene_cls = getattr(module, entry.scene_cls)
+                self.next_scene = scene_cls(self.app)
+            except Exception:
+                pass
+            return
 
     def _handle_modal_event(self, event):
         if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
@@ -321,6 +651,15 @@ class MainMenuScene(C.Scene):
 
         if e.type == pygame.MOUSEBUTTONUP and e.button == 1:
             self._scroll_dragging = False
+
+        if self._options_modal is not None:
+            should_close = False
+            if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP, pygame.MOUSEMOTION, pygame.KEYDOWN):
+                should_close = self._options_modal.handle_event(e)
+            if should_close:
+                self._options_modal = None
+                self._options_proxy = None
+            return
 
         if self._modal_open:
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP, pygame.MOUSEMOTION, pygame.KEYDOWN):
@@ -437,6 +776,8 @@ class MainMenuScene(C.Scene):
         self._draw_menu_button(screen)
         if self._modal_open:
             self._draw_modal(screen)
+        if self._options_modal is not None:
+            self._options_modal.draw(screen)
 
 
 

--- a/src/solitaire/scenes/menu_options.py
+++ b/src/solitaire/scenes/menu_options.py
@@ -1,0 +1,833 @@
+"""Controllers for game option modals on the main menu."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Sequence
+
+from solitaire import common as C
+
+
+@dataclass
+class OptionState:
+    """Represents a selectable option row in the game modal."""
+
+    key: str
+    label: str
+    values: Sequence[Any]
+    index: int = 0
+    formatter: Callable[[Any], str] = str
+
+    def current_value(self) -> Any:
+        if not self.values:
+            return None
+        return self.values[self.index % len(self.values)]
+
+    def current_text(self) -> str:
+        value = self.current_value()
+        return self.formatter(value)
+
+    def step(self, delta: int) -> None:
+        if not self.values:
+            return
+        self.index = (self.index + delta) % len(self.values)
+
+
+@dataclass
+class ButtonState:
+    """Metadata for an action button in the game modal."""
+
+    key: str
+    label: str
+    enabled: bool = True
+    variant: str = "default"  # "default", "cancel", "primary"
+
+
+@dataclass
+class ActionResult:
+    """Return value from controller button handlers."""
+
+    close_modal: bool = False
+
+
+class GameOptionsController:
+    """Base controller that describes actions and options for a game."""
+
+    def __init__(self, menu_scene, *, metadata) -> None:
+        self.menu_scene = menu_scene
+        self.app = menu_scene.app
+        self.metadata = metadata
+        self._options: List[OptionState] = []
+        self._message: str = ""
+
+    # ----- lifecycle -------------------------------------------------
+    def refresh(self) -> None:
+        """Update any dynamic state prior to drawing."""
+
+    # ----- helpers ---------------------------------------------------
+    @property
+    def message(self) -> str:
+        return self._message
+
+    def set_message(self, text: str = "") -> None:
+        self._message = text
+
+    def title(self) -> str:
+        label = self.metadata.label.replace("\n", " ") if self.metadata else "Game"
+        return f"{label} Options"
+
+    # ----- options ---------------------------------------------------
+    def options(self) -> Iterable[OptionState]:
+        return self._options
+
+    def change_option(self, key: str, delta: int) -> None:
+        lookup: Dict[str, OptionState] = {opt.key: opt for opt in self._options}
+        option = lookup.get(key)
+        if option is None:
+            return
+        option.step(delta)
+        self.on_option_changed(option)
+
+    def on_option_changed(self, option: OptionState) -> None:
+        """Hook invoked whenever an option value changes."""
+
+    # ----- buttons ---------------------------------------------------
+    def buttons(self) -> Sequence[ButtonState]:
+        return []
+
+    def handle_button(self, key: str) -> ActionResult:
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        """Mapping of legacy button attribute names to action keys."""
+
+        return {}
+
+
+# --- Accordion -------------------------------------------------------
+
+from solitaire.modes import accordion as accordion_mode
+
+
+class AccordionController(GameOptionsController):
+    def __init__(self, menu_scene, *, metadata) -> None:
+        super().__init__(menu_scene, metadata=metadata)
+        difficulties = [
+            ("easy", "Easy — win with 7 piles or fewer"),
+            ("normal", "Normal — win with 4 piles or fewer"),
+            ("hard", "Hard — win with 1 pile"),
+        ]
+        self._options = [
+            OptionState(
+                key="difficulty",
+                label="Difficulty",
+                values=difficulties,
+                index=1,
+                formatter=lambda item: f"{accordion_mode.get_difficulty_label(item[0])}",
+            )
+        ]
+
+    def _has_save(self) -> bool:
+        return accordion_mode.has_saved_game()
+
+    def _resume_label(self) -> str:
+        if not self._has_save():
+            return "Resume"
+        summary = accordion_mode.peek_saved_game_summary()
+        if summary:
+            return f"Resume ({summary})"
+        return "Resume"
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", self._resume_label(), enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            accordion_mode.delete_saved_game()
+            difficulty_key, _ = self._options[0].current_value()
+            self.menu_scene.next_scene = accordion_mode.AccordionGameScene(
+                self.app, difficulty=difficulty_key
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume":
+            if not self._has_save():
+                return ActionResult(close_modal=False)
+            state = accordion_mode.load_saved_game()
+            if not state:
+                return ActionResult(close_modal=False)
+            self.menu_scene.next_scene = accordion_mode.AccordionGameScene(
+                self.app, load_state=state
+            )
+            return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_new": "start", "b_continue": "resume", "b_back": "cancel"}
+
+
+# --- Beleaguered Castle ----------------------------------------------
+
+from solitaire.modes import beleaguered_castle as beleaguered_castle_mode
+
+
+class BeleagueredCastleController(GameOptionsController):
+    def _has_save(self) -> bool:
+        state = beleaguered_castle_mode._safe_read_json(
+            beleaguered_castle_mode._bc_save_path()
+        )
+        return bool(state) and not state.get("completed", False)
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", "Resume", enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            beleaguered_castle_mode._clear_saved_game()
+            self.menu_scene.next_scene = (
+                beleaguered_castle_mode.BeleagueredCastleGameScene(
+                    self.app, load_state=None
+                )
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume" and self._has_save():
+            state = beleaguered_castle_mode._safe_read_json(
+                beleaguered_castle_mode._bc_save_path()
+            )
+            if state:
+                self.menu_scene.next_scene = (
+                    beleaguered_castle_mode.BeleagueredCastleGameScene(
+                        self.app, load_state=state
+                    )
+                )
+                return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_resume": "resume", "b_back": "cancel"}
+
+
+# --- Big Ben ---------------------------------------------------------
+
+from solitaire.modes import big_ben as big_ben_mode
+
+
+class BigBenController(GameOptionsController):
+    def _has_save(self) -> bool:
+        state = big_ben_mode._safe_read_json(big_ben_mode._bb_save_path())
+        return bool(state) and not state.get("completed", False)
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", "Resume", enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            big_ben_mode._clear_saved_game()
+            self.menu_scene.next_scene = big_ben_mode.BigBenGameScene(
+                self.app, load_state=None
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume" and self._has_save():
+            state = big_ben_mode._safe_read_json(big_ben_mode._bb_save_path())
+            if state:
+                self.menu_scene.next_scene = big_ben_mode.BigBenGameScene(
+                    self.app, load_state=state
+                )
+                return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_resume": "resume", "b_back": "cancel"}
+
+
+# --- Bowling Solitaire -----------------------------------------------
+
+from solitaire.modes import bowling_solitaire as bowling_mode
+
+
+class BowlingSolitaireController(GameOptionsController):
+    def buttons(self) -> Sequence[ButtonState]:
+        has_save = bowling_mode.has_saved_game()
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", "Resume", enabled=has_save),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            self.set_message("")
+            return ActionResult(close_modal=True)
+        if key == "start":
+            self.set_message("")
+            self.menu_scene.next_scene = bowling_mode.BowlingSolitaireGameScene(
+                self.app
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume":
+            load_state = bowling_mode.load_saved_game()
+            if not load_state:
+                self.set_message("No saved game found.")
+                return ActionResult(close_modal=False)
+            self.set_message("")
+            self.menu_scene.next_scene = bowling_mode.BowlingSolitaireGameScene(
+                self.app, load_state=load_state
+            )
+            return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_continue": "resume", "b_back": "cancel"}
+
+
+# --- Chameleon -------------------------------------------------------
+
+from solitaire.modes import chameleon as chameleon_mode
+
+
+class ChameleonController(GameOptionsController):
+    def __init__(self, menu_scene, *, metadata) -> None:
+        super().__init__(menu_scene, metadata=metadata)
+        cfg = chameleon_mode.load_chameleon_config()
+        self.stock_cycles = cfg.get("stock_cycles")
+        values: List[Any] = [None, 0, 1]
+        if self.stock_cycles not in values and self.stock_cycles is not None:
+            values.append(self.stock_cycles)
+        index = values.index(self.stock_cycles) if self.stock_cycles in values else 0
+        self._options = [
+            OptionState(
+                key="redeals",
+                label="Redeals",
+                values=values,
+                index=index,
+                formatter=self._format_value,
+            )
+        ]
+
+    def _format_value(self, value: Any) -> str:
+        if value is None:
+            return "Unlimited"
+        if value <= 0:
+            return "None"
+        if value == 1:
+            return "1 Redeal"
+        return f"{value} Redeals"
+
+    def on_option_changed(self, option: OptionState) -> None:
+        self.stock_cycles = option.current_value()
+        chameleon_mode.save_chameleon_config(self.stock_cycles)
+        chameleon_mode.update_saved_stock_cycles(self.stock_cycles)
+
+    def _has_save(self) -> bool:
+        return chameleon_mode.chameleon_save_exists()
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", "Resume", enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            chameleon_mode.clear_saved_state()
+            self.menu_scene.next_scene = chameleon_mode.ChameleonGameScene(
+                self.app, load_state=None, stock_cycles=self.stock_cycles
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume" and self._has_save():
+            state = chameleon_mode.load_saved_state()
+            if state and not state.get("completed"):
+                state["stock_cycles_allowed"] = self.stock_cycles
+                if (
+                    self.stock_cycles is not None
+                    and state.get("stock_cycles_used", 0) > self.stock_cycles
+                ):
+                    state["stock_cycles_used"] = self.stock_cycles
+                self.menu_scene.next_scene = chameleon_mode.ChameleonGameScene(
+                    self.app, load_state=state, stock_cycles=self.stock_cycles
+                )
+                return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_continue": "resume", "b_back": "cancel"}
+
+
+# --- Demon -----------------------------------------------------------
+
+from solitaire.modes import demon as demon_mode
+
+
+class DemonController(GameOptionsController):
+    def __init__(self, menu_scene, *, metadata) -> None:
+        super().__init__(menu_scene, metadata=metadata)
+        cfg = demon_mode.load_demon_config()
+        self.stock_cycles = cfg.get("stock_cycles")
+        values: List[Any] = [None, 3, 1]
+        if self.stock_cycles not in values:
+            values.append(self.stock_cycles)
+        index = values.index(self.stock_cycles) if self.stock_cycles in values else 0
+        self._options = [
+            OptionState(
+                key="stock",
+                label="Stock Replays",
+                values=values,
+                index=index,
+                formatter=self._format_value,
+            )
+        ]
+
+    def _format_value(self, value: Any) -> str:
+        if value is None:
+            return "Unlimited"
+        return "1 Replay" if value == 1 else f"{value} Replays"
+
+    def on_option_changed(self, option: OptionState) -> None:
+        self.stock_cycles = option.current_value()
+        demon_mode.save_demon_config(self.stock_cycles)
+        demon_mode.update_saved_stock_cycles(self.stock_cycles)
+
+    def _has_save(self) -> bool:
+        return demon_mode.demon_save_exists()
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", "Resume", enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            demon_mode.clear_saved_state()
+            self.menu_scene.next_scene = demon_mode.DemonGameScene(
+                self.app, load_state=None, stock_cycles=self.stock_cycles
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume" and self._has_save():
+            state = demon_mode.load_saved_state()
+            if state and not state.get("completed"):
+                state["stock_cycles_allowed"] = self.stock_cycles
+                if (
+                    self.stock_cycles is not None
+                    and state.get("stock_cycles_used", 0) > self.stock_cycles
+                ):
+                    state["stock_cycles_used"] = self.stock_cycles
+                self.menu_scene.next_scene = demon_mode.DemonGameScene(
+                    self.app, load_state=state, stock_cycles=self.stock_cycles
+                )
+                return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_continue": "resume", "b_back": "cancel"}
+
+
+# --- Duchess ---------------------------------------------------------
+
+from solitaire.modes import duchess as duchess_mode
+
+
+class DuchessController(GameOptionsController):
+    def _has_save(self) -> bool:
+        return duchess_mode.duchess_save_exists()
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", "Resume", enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            duchess_mode.clear_saved_state()
+            self.menu_scene.next_scene = duchess_mode.DuchessGameScene(
+                self.app, load_state=None
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume" and self._has_save():
+            state = duchess_mode.load_saved_state()
+            if state and not state.get("completed"):
+                self.menu_scene.next_scene = duchess_mode.DuchessGameScene(
+                    self.app, load_state=state
+                )
+                return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_continue": "resume", "b_back": "cancel"}
+
+
+# --- FreeCell --------------------------------------------------------
+
+from solitaire.modes import freecell as freecell_mode
+
+
+class FreeCellController(GameOptionsController):
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            self.menu_scene.next_scene = freecell_mode.FreeCellGameScene(self.app)
+            return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_back": "cancel"}
+
+
+# --- Gate ------------------------------------------------------------
+
+from solitaire.modes import gate as gate_mode
+
+
+class GateController(GameOptionsController):
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            self.menu_scene.next_scene = gate_mode.GateGameScene(self.app)
+            return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_back": "cancel"}
+
+
+# --- Golf ------------------------------------------------------------
+
+from solitaire.modes import golf as golf_mode
+
+
+class GolfController(GameOptionsController):
+    def __init__(self, menu_scene, *, metadata) -> None:
+        super().__init__(menu_scene, metadata=metadata)
+        self._holes_values = [1, 3, 9, 18]
+        self._options = [
+            OptionState(
+                key="holes",
+                label="Course Length",
+                values=self._holes_values,
+                index=0,
+                formatter=lambda v: f"{v} Hole{'s' if v != 1 else ''}",
+            ),
+            OptionState(
+                key="around",
+                label="Around the Corner",
+                values=[True, False],
+                index=0,
+                formatter=lambda v: "On" if v else "Off",
+            ),
+        ]
+
+    def on_option_changed(self, option: OptionState) -> None:
+        if option.key == "holes":
+            return
+
+    def _holes(self) -> int:
+        return int(self._options[0].current_value())
+
+    def _around_flag(self) -> bool:
+        return bool(self._options[1].current_value())
+
+    def _has_save(self) -> bool:
+        state = golf_mode._safe_read_json(golf_mode._golf_save_path())
+        return bool(state) and not state.get("completed", False)
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("scores", "Scores"),
+            ButtonState("resume", "Resume", enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "scores":
+            self.menu_scene.next_scene = golf_mode.GolfScoresScene(self.app)
+            return ActionResult(close_modal=True)
+        if key == "start":
+            try:
+                save_path = golf_mode._golf_save_path()
+                import os
+
+                if os.path.isfile(save_path):
+                    os.remove(save_path)
+            except Exception:
+                pass
+            self.menu_scene.next_scene = golf_mode.GolfGameScene(
+                self.app,
+                holes_total=self._holes(),
+                around=self._around_flag(),
+                load_state=None,
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume" and self._has_save():
+            load_state = golf_mode._safe_read_json(golf_mode._golf_save_path())
+            if load_state:
+                self.menu_scene.next_scene = golf_mode.GolfGameScene(
+                    self.app,
+                    holes_total=load_state.get("holes_total", 1),
+                    around=bool(load_state.get("around", False)),
+                    load_state=load_state,
+                )
+                return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {
+            "b_new1": "start",
+            "b_continue": "resume",
+            "b_scores": "scores",
+            "b_back": "cancel",
+        }
+
+
+# --- Klondike --------------------------------------------------------
+
+from solitaire.modes import klondike as klondike_mode
+
+
+class KlondikeController(GameOptionsController):
+    def __init__(self, menu_scene, *, metadata) -> None:
+        super().__init__(menu_scene, metadata=metadata)
+        difficulty_values = [None, 2, 1]
+        self._options = [
+            OptionState(
+                key="difficulty",
+                label="Stock Cycles",
+                values=difficulty_values,
+                index=0,
+                formatter=self._format_difficulty,
+            ),
+            OptionState(
+                key="draw",
+                label="Draw Mode",
+                values=[3, 1],
+                index=0,
+                formatter=lambda v: f"Draw {v}",
+            ),
+        ]
+
+    def _format_difficulty(self, value: Any) -> str:
+        if value is None:
+            return "Unlimited"
+        if value == 2:
+            return "2 Cycles"
+        if value == 1:
+            return "1 Cycle"
+        return str(value)
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            draw_count = int(self._options[1].current_value())
+            stock_cycles = self._options[0].current_value()
+            self.menu_scene.next_scene = klondike_mode.KlondikeGameScene(
+                self.app,
+                draw_count=draw_count,
+                stock_cycles=stock_cycles,
+            )
+            return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_back": "cancel"}
+
+
+# --- Pyramid ---------------------------------------------------------
+
+from solitaire.modes import pyramid as pyramid_mode
+
+
+class PyramidController(GameOptionsController):
+    def __init__(self, menu_scene, *, metadata) -> None:
+        super().__init__(menu_scene, metadata=metadata)
+        self._options = [
+            OptionState(
+                key="difficulty",
+                label="Resets",
+                values=[None, 2, 1],
+                index=0,
+                formatter=self._format_value,
+            )
+        ]
+
+    def _format_value(self, value: Any) -> str:
+        if value is None:
+            return "Unlimited"
+        if value == 2:
+            return "2 Resets"
+        if value == 1:
+            return "1 Reset"
+        return str(value)
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            allowed = self._options[0].current_value()
+            self.menu_scene.next_scene = pyramid_mode.PyramidGameScene(
+                self.app, allowed_resets=allowed
+            )
+            return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_back": "cancel"}
+
+
+# --- TriPeaks --------------------------------------------------------
+
+from solitaire.modes import tripeaks as tripeaks_mode
+
+
+class TriPeaksController(GameOptionsController):
+    def __init__(self, menu_scene, *, metadata) -> None:
+        super().__init__(menu_scene, metadata=metadata)
+        self._options = [
+            OptionState(
+                key="wrap",
+                label="Wrap A↔K",
+                values=[True, False],
+                index=0,
+                formatter=lambda v: "On" if v else "Off",
+            )
+        ]
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            wrap = bool(self._options[0].current_value())
+            self.menu_scene.next_scene = tripeaks_mode.TriPeaksGameScene(
+                self.app, wrap_ak=wrap
+            )
+            return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_back": "cancel"}
+
+
+# --- Yukon -----------------------------------------------------------
+
+from solitaire.modes import yukon as yukon_mode
+
+
+class YukonController(GameOptionsController):
+    def _has_save(self) -> bool:
+        state = yukon_mode._safe_read_json(yukon_mode._yukon_save_path())
+        return bool(state) and not state.get("completed", False)
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", "Resume", enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            try:
+                import os
+
+                save_path = yukon_mode._yukon_save_path()
+                if os.path.isfile(save_path):
+                    os.remove(save_path)
+            except Exception:
+                pass
+            self.menu_scene.next_scene = yukon_mode.YukonGameScene(
+                self.app, load_state=None
+            )
+            return ActionResult(close_modal=True)
+        if key == "resume" and self._has_save():
+            state = yukon_mode._safe_read_json(yukon_mode._yukon_save_path())
+            if state:
+                self.menu_scene.next_scene = yukon_mode.YukonGameScene(
+                    self.app, load_state=state
+                )
+                return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_continue": "resume", "b_back": "cancel"}
+
+
+CONTROLLER_REGISTRY = {
+    "accordion": AccordionController,
+    "beleaguered_castle": BeleagueredCastleController,
+    "big_ben": BigBenController,
+    "bowling_solitaire": BowlingSolitaireController,
+    "chameleon": ChameleonController,
+    "demon": DemonController,
+    "duchess": DuchessController,
+    "freecell": FreeCellController,
+    "gate": GateController,
+    "golf": GolfController,
+    "klondike": KlondikeController,
+    "pyramid": PyramidController,
+    "tripeaks": TriPeaksController,
+    "yukon": YukonController,
+}
+


### PR DESCRIPTION
## Summary
- replace the per-game option scenes with an in-place GameOptionsModal overlay on the main menu
- centralize game option logic in new menu_options controllers that expose selectors and action metadata
- update ModeUIHelper to reopen the new modal when returning to the menu while keeping legacy hooks for tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d97d379e388321952d6addba8cd26a