### PR TITLE
Replace in-game menu with modal and center options titles

### DIFF
--- a/src/solitaire/modes/accordion.py
+++ b/src/solitaire/modes/accordion.py
@@ -452,6 +452,8 @@ class AccordionGameScene(C.Scene):
             ):
                 return
 
+        if self.ui_helper.handle_menu_event(event):
+            return
         if self.toolbar.handle_event(event):
             return
         if self.ui_helper.handle_shortcuts(event):
@@ -516,6 +518,7 @@ class AccordionGameScene(C.Scene):
 
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
     def _draw_dragged_stack(self, screen) -> None:
         info = self.drag_info

--- a/src/solitaire/modes/beleaguered_castle.py
+++ b/src/solitaire/modes/beleaguered_castle.py
@@ -518,6 +518,8 @@ class BeleagueredCastleGameScene(C.Scene):
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN):
                 return
 
+        if self.ui_helper.handle_menu_event(e):
+            return
         if self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
@@ -703,6 +705,7 @@ class BeleagueredCastleGameScene(C.Scene):
         self.toolbar.draw(screen)
         if self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
         # Draw scrollbars last
         vsb = self._vertical_scrollbar()

--- a/src/solitaire/modes/big_ben.py
+++ b/src/solitaire/modes/big_ben.py
@@ -598,6 +598,8 @@ class BigBenGameScene(C.Scene):
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN):
                 return
 
+        if self.ui_helper.handle_menu_event(e):
+            return
         if self.drag_pan.handle_event(e, target=self, clamp=self._clamp_scroll_xy):
             self.peek.cancel()
             return
@@ -849,6 +851,7 @@ class BigBenGameScene(C.Scene):
         # Help overlay on top
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
         
     def debug_state(self):
         return {

--- a/src/solitaire/modes/bowling_solitaire.py
+++ b/src/solitaire/modes/bowling_solitaire.py
@@ -1157,6 +1157,7 @@ class BowlingSolitaireGameScene(C.Scene):
         self._draw_status(screen)
         if self._discard_modal_visible:
             self._draw_discard_modal(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
     def _draw_scoreboard(self, screen: pygame.Surface) -> None:
         sx = self.scroll_x
@@ -1433,6 +1434,8 @@ class BowlingSolitaireGameScene(C.Scene):
                 return
             if event.type in (pygame.MOUSEBUTTONDOWN, pygame.KEYDOWN):
                 return
+        if self.ui_helper.handle_menu_event(event):
+            return
         if self.toolbar and self.toolbar.handle_event(event):
             return
         if self.ui_helper.handle_shortcuts(event):

--- a/src/solitaire/modes/chameleon.py
+++ b/src/solitaire/modes/chameleon.py
@@ -482,6 +482,8 @@ class ChameleonGameScene(ScrollableSceneMixin, C.Scene):
             if event.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
                 return
 
+        if self.ui_helper.handle_menu_event(event):
+            return
         if self.handle_scroll_event(event):
             return
 
@@ -649,6 +651,7 @@ class ChameleonGameScene(ScrollableSceneMixin, C.Scene):
         self.toolbar.draw(screen)
         if self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
     def update(self, dt):
         pass

--- a/src/solitaire/modes/demon.py
+++ b/src/solitaire/modes/demon.py
@@ -486,6 +486,8 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
             if event.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
                 return
 
+        if self.ui_helper.handle_menu_event(event):
+            return
         if self.handle_scroll_event(event):
             return
 
@@ -653,6 +655,7 @@ class DemonGameScene(ScrollableSceneMixin, C.Scene):
         self.toolbar.draw(screen)
         if self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
     def update(self, dt):
         pass

--- a/src/solitaire/modes/duchess.py
+++ b/src/solitaire/modes/duchess.py
@@ -501,6 +501,8 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
             if event.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
                 return
 
+        if self.ui_helper.handle_menu_event(event):
+            return
         if self.handle_scroll_event(event):
             return
 
@@ -663,6 +665,7 @@ class DuchessGameScene(ScrollableSceneMixin, C.Scene):
         self.toolbar.draw(screen)
         if self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
     def update(self, dt):
         pass

--- a/src/solitaire/modes/freecell.py
+++ b/src/solitaire/modes/freecell.py
@@ -306,6 +306,8 @@ class FreeCellGameScene(C.Scene):
                 else:
                     self.help.open()
                 return
+        if self.ui_helper.handle_menu_event(e):
+            return
         if self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
@@ -613,3 +615,4 @@ class FreeCellGameScene(C.Scene):
         self.toolbar.draw(screen)
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)

--- a/src/solitaire/modes/gate.py
+++ b/src/solitaire/modes/gate.py
@@ -436,6 +436,8 @@ class GateGameScene(C.Scene):
                 return
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
                 return
+        if self.ui_helper.handle_menu_event(e):
+            return
         if self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
@@ -680,6 +682,7 @@ class GateGameScene(C.Scene):
         self.toolbar.draw(screen)
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
         # Activate any pending peek by time
         self.peek.maybe_activate(pygame.time.get_ticks())

--- a/src/solitaire/modes/golf.py
+++ b/src/solitaire/modes/golf.py
@@ -522,6 +522,8 @@ class GolfGameScene(C.Scene):
                 return
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
                 return
+        if self.ui_helper.handle_menu_event(e):
+            return
         if self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
@@ -844,6 +846,7 @@ class GolfGameScene(C.Scene):
         self.toolbar.draw(screen)
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
 
 class GolfScoresScene(C.Scene):

--- a/src/solitaire/modes/klondike.py
+++ b/src/solitaire/modes/klondike.py
@@ -379,6 +379,8 @@ class KlondikeGameScene(C.Scene):
                 else:
                     self.help.open()
                 return
+        if self.ui_helper.handle_menu_event(e):
+            return
         if self.toolbar.handle_event(e):
             return
         if self.ui_helper.handle_shortcuts(e):
@@ -615,6 +617,7 @@ class KlondikeGameScene(C.Scene):
         # Help overlay on top
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
     # ---------- Scrollbar geometry helpers ----------
     def _vertical_scrollbar(self):

--- a/src/solitaire/modes/pyramid.py
+++ b/src/solitaire/modes/pyramid.py
@@ -459,6 +459,7 @@ class PyramidGameScene(C.Scene):
         self.toolbar.draw(screen)
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
     # ---------- Scrollbar geometry helpers ----------
     def _vertical_scrollbar(self):
@@ -515,6 +516,8 @@ class PyramidGameScene(C.Scene):
                 return
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
                 return
+        if self.ui_helper.handle_menu_event(e):
+            return
         # Toolbar first
         if self.toolbar.handle_event(e):
             return

--- a/src/solitaire/modes/tripeaks.py
+++ b/src/solitaire/modes/tripeaks.py
@@ -493,6 +493,7 @@ class TriPeaksGameScene(C.Scene):
         self.toolbar.draw(screen)
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
     # ---------- Events ----------
     def handle_event(self, e):
@@ -502,6 +503,8 @@ class TriPeaksGameScene(C.Scene):
                 return
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
                 return
+        if self.ui_helper.handle_menu_event(e):
+            return
         # Toolbar first
         if hasattr(self, "toolbar") and self.toolbar.handle_event(e):
             return

--- a/src/solitaire/modes/yukon.py
+++ b/src/solitaire/modes/yukon.py
@@ -393,6 +393,8 @@ class YukonGameScene(C.Scene):
                 return
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
                 return
+        if self.ui_helper.handle_menu_event(e):
+            return
 
         if self.toolbar.handle_event(e):
             return
@@ -707,6 +709,7 @@ class YukonGameScene(C.Scene):
         self.toolbar.draw(screen)
         if getattr(self, "help", None) and self.help.visible:
             self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
 
         # Scrollbars
         vsb = self._vertical_scrollbar()

--- a/src/solitaire/scenes/menu.py
+++ b/src/solitaire/scenes/menu.py
@@ -42,11 +42,11 @@ class _GameEntry:
 
 
 class _OptionRowLayout:
-    __slots__ = ("key", "label_pos", "value_rect", "left_rect", "right_rect")
+    __slots__ = ("key", "label_y", "value_rect", "left_rect", "right_rect")
 
-    def __init__(self, key: str, label_pos, value_rect, left_rect, right_rect) -> None:
+    def __init__(self, key: str, label_y: int, value_rect, left_rect, right_rect) -> None:
         self.key = key
-        self.label_pos = label_pos
+        self.label_y = label_y
         self.value_rect = value_rect
         self.left_rect = left_rect
         self.right_rect = right_rect
@@ -125,7 +125,7 @@ class GameOptionsModal:
         self._options_layout = []
         value_width = self.rect.width - 2 * self.PADDING_X - 2 * (self.OPTION_ARROW + self.OPTION_ARROW_GAP)
         for key, label_y, value_y in relative_rows:
-            label_pos = (self.rect.x + self.PADDING_X, self.rect.y + label_y)
+            label_y_abs = self.rect.y + label_y
             value_rect = pygame.Rect(
                 self.rect.x + self.PADDING_X + self.OPTION_ARROW + self.OPTION_ARROW_GAP,
                 self.rect.y + value_y,
@@ -144,7 +144,7 @@ class GameOptionsModal:
                 self.OPTION_ARROW,
                 self.OPTION_HEIGHT,
             )
-            self._options_layout.append(_OptionRowLayout(key, label_pos, value_rect, left_rect, right_rect))
+            self._options_layout.append(_OptionRowLayout(key, label_y_abs, value_rect, left_rect, right_rect))
 
         self._message_rect = pygame.Rect(
             self.rect.x + self.PADDING_X,
@@ -273,7 +273,7 @@ class GameOptionsModal:
             if opt is None:
                 continue
             label_surf = label_font.render(opt.label, True, (60, 60, 65))
-            screen.blit(label_surf, layout.label_pos)
+            screen.blit(label_surf, (self.rect.centerx - label_surf.get_width() // 2, layout.label_y))
             value_text = opt.current_text()
             self._draw_value_box(screen, layout.value_rect, value_text)
             arrows_enabled = len(opt.values) > 1


### PR DESCRIPTION
## Summary
- replace the toolbar dropdown with a reusable modal menu that exposes game, save, quit, help, and hint actions with confirmation before restarting
- wire every solitaire scene to route events and drawing through the new modal and keep ESC toggling the menu
- center option labels in the main menu options dialog for cleaner presentation

## Testing
- python -m compileall src/solitaire

------
https://chatgpt.com/codex/tasks/task_e_68d997e05b008321972deca812d61744