### PR TITLE
Route game option buttons through modal

### DIFF
--- a/src/solitaire/modes/klondike.py
+++ b/src/solitaire/modes/klondike.py
@@ -3,48 +3,19 @@ import pygame
 from collections import deque
 from solitaire import common as C
 
-def is_red(suit): return suit in (1,2)
 
-class KlondikeOptionsScene(C.Scene):
-    def __init__(self, app):
-        super().__init__(app)
-        self.diff_index = 0  # 0: Easy(∞), 1: Medium(2), 2: Hard(1)
-        self.draw_mode = 3   # 1 or 3
-        cx = C.SCREEN_W//2 - 210
-        y = 260
-        self.b_start = C.Button("Start Klondike", cx, y); y+=60
-        self.b_diff  = C.Button("Difficulty: Easy (Unlimited stock cycles)", cx, y, w=420); y+=60
-        self.b_draw  = C.Button("Draw: 3", cx, y, w=420); y+=60
-        y+=10
-        self.b_back  = C.Button("Back", cx, y)
+KLONDIKE_DIFFICULTY_LABELS = [
+    "Easy (Unlimited stock cycles)",
+    "Medium (2 stock cycles)",
+    "Hard (1 stock cycle)",
+]
 
-    def handle_event(self, e):
-        if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
-            mx,my = e.pos
-            if self.b_start.hovered((mx,my)):
-                self.next_scene = KlondikeGameScene(self.app, draw_count=self.draw_mode, stock_cycles=[None,2,1][self.diff_index])
-            elif self.b_diff.hovered((mx,my)):
-                self.diff_index = (self.diff_index + 1) % 3
-                txt = ["Easy (Unlimited stock cycles)","Medium (2 stock cycles)","Hard (1 stock cycle)"][self.diff_index]
-                self.b_diff.text = "Difficulty: " + txt
-            elif self.b_draw.hovered((mx,my)):
-                self.draw_mode = 1 if self.draw_mode == 3 else 3
-                self.b_draw.text = f"Draw: {self.draw_mode}"
-            elif self.b_back.hovered((mx,my)):
-                from solitaire.scenes.menu import MainMenuScene
-                self.next_scene = MainMenuScene(self.app)
-        elif e.type == pygame.KEYDOWN:
-            if e.key == pygame.K_ESCAPE:
-                from solitaire.scenes.menu import MainMenuScene
-                self.next_scene = MainMenuScene(self.app)
+KLONDIKE_STOCK_CYCLE_LIMITS = [None, 2, 1]
 
-    def draw(self, screen):
-        screen.fill(C.TABLE_BG)
-        title = C.FONT_TITLE.render("Klondike – Options", True, C.WHITE)
-        screen.blit(title, (C.SCREEN_W//2 - title.get_width()//2, 120))
-        mp = pygame.mouse.get_pos()
-        for b in [self.b_start, self.b_diff, self.b_draw, self.b_back]:
-            b.draw(screen, hover=b.hovered(mp))
+
+def is_red(suit):
+    return suit in (1, 2)
+
 
 class KlondikeGameScene(C.Scene):
     def __init__(self, app, draw_count=3, stock_cycles=None):

--- a/src/solitaire/scenes/game_options_modal.py
+++ b/src/solitaire/scenes/game_options_modal.py
@@ -1,0 +1,152 @@
+"""Reusable modal for configuring game options before starting a module."""
+
+from __future__ import annotations
+
+import pygame
+
+from solitaire import common as C
+
+
+class _ModalOption:
+    """Container for a single configurable option inside the modal."""
+
+    def __init__(self, label_func, on_click, x, y, width):
+        self._label_func = label_func
+        self._on_click = on_click
+        self.button = C.Button("", x, y, w=width, h=48)
+        self.refresh()
+
+    def refresh(self):
+        self.button.text = self._label_func()
+
+    def click(self):
+        self._on_click()
+        self.refresh()
+
+
+class GameOptionsModal:
+    """Simple modal overlay used to tweak game settings before starting."""
+
+    PANEL_WIDTH = 560
+    PANEL_HEIGHT = 420
+
+    def __init__(self, title, start_label, option_specs):
+        """Create a modal.
+
+        Args:
+            title: Heading to display at the top of the modal.
+            start_label: Text for the primary "start" button.
+            option_specs: Iterable of ``(label_func, on_click)`` pairs used to
+                create interactive option buttons.
+        """
+
+        self.title = title
+        self._start_label = start_label
+        self._options = []
+        self.visible = False
+
+        panel_x = (C.SCREEN_W - self.PANEL_WIDTH) // 2
+        panel_y = (C.SCREEN_H - self.PANEL_HEIGHT) // 2
+        self.panel_rect = pygame.Rect(panel_x, panel_y, self.PANEL_WIDTH, self.PANEL_HEIGHT)
+
+        content_x = self.panel_rect.left + 40
+        y = self.panel_rect.top + 140
+        option_width = self.PANEL_WIDTH - 80
+        for label_func, on_click in option_specs:
+            opt = _ModalOption(label_func, on_click, content_x, y, option_width)
+            self._options.append(opt)
+            y += 64
+
+        button_y = self.panel_rect.bottom - 92
+        self._start_button = C.Button(self._start_label, content_x, button_y, w=220, h=48)
+        cancel_x = self.panel_rect.right - 40 - 160
+        self._cancel_button = C.Button("Cancel", cancel_x, button_y, w=160, h=48)
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers
+    def open(self):
+        self.visible = True
+        self.refresh()
+
+    def close(self):
+        self.visible = False
+
+    def refresh(self):
+        for opt in self._options:
+            opt.refresh()
+        self._start_button.text = self._start_label
+
+    # ------------------------------------------------------------------
+    def handle_event(self, event):
+        """Handle pygame events.
+
+        Returns:
+            ``"start"`` when the start button was clicked,
+            ``"close"`` when the modal should close,
+            ``"consumed"`` if the event was handled otherwise,
+            or ``None`` if the modal is not visible.
+        """
+
+        if not self.visible:
+            return None
+
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            mouse = event.pos
+            if self._start_button.hovered(mouse):
+                return "start"
+            if self._cancel_button.hovered(mouse):
+                self.close()
+                return "close"
+            for opt in self._options:
+                if opt.button.hovered(mouse):
+                    opt.click()
+                    return "consumed"
+            if not self.panel_rect.collidepoint(mouse):
+                self.close()
+                return "close"
+            return "consumed"
+
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_ESCAPE:
+                self.close()
+                return "close"
+            return "consumed"
+
+        if event.type in (pygame.MOUSEMOTION, pygame.MOUSEWHEEL):
+            return "consumed"
+
+        return "consumed"
+
+    def draw(self, screen):
+        if not self.visible:
+            return
+
+        # Dim background
+        overlay = pygame.Surface((C.SCREEN_W, C.SCREEN_H), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 150))
+        screen.blit(overlay, (0, 0))
+
+        # Panel
+        pygame.draw.rect(screen, C.LIGHT, self.panel_rect, border_radius=18)
+        pygame.draw.rect(screen, C.BLACK, self.panel_rect, 2, border_radius=18)
+
+        title_text = C.FONT_TITLE.render(self.title, True, C.BLACK)
+        title_pos = (
+            self.panel_rect.centerx - title_text.get_width() // 2,
+            self.panel_rect.top + 50,
+        )
+        screen.blit(title_text, title_pos)
+
+        subtitle = C.FONT_SMALL.render("Adjust the settings before starting.", True, C.BLACK)
+        subtitle_pos = (
+            self.panel_rect.centerx - subtitle.get_width() // 2,
+            title_pos[1] + title_text.get_height() + 10,
+        )
+        screen.blit(subtitle, subtitle_pos)
+
+        mouse_pos = pygame.mouse.get_pos()
+        for opt in self._options:
+            opt.button.draw(screen, hover=opt.button.hovered(mouse_pos))
+        self._start_button.draw(screen, hover=self._start_button.hovered(mouse_pos))
+        self._cancel_button.draw(screen, hover=self._cancel_button.hovered(mouse_pos))
+

--- a/src/solitaire/scenes/menu.py
+++ b/src/solitaire/scenes/menu.py
@@ -2,6 +2,12 @@
 # menu.py - Main menu
 import pygame
 from solitaire import common as C
+from solitaire.modes.klondike import (
+    KLONDIKE_DIFFICULTY_LABELS,
+    KLONDIKE_STOCK_CYCLE_LIMITS,
+    KlondikeGameScene,
+)
+from solitaire.scenes.game_options_modal import GameOptionsModal
 
 class MainMenuScene(C.Scene):
     def __init__(self, app):
@@ -11,13 +17,41 @@ class MainMenuScene(C.Scene):
         self.b_klon = C.Button("Play Klondike", cx, y, center=True); y += 60
         self.b_quit = C.Button("Quit", cx, y, center=True)
 
+        # Track any open modal so we can forward events appropriately
+        self._active_modal = None
+        self._active_modal_start = None
+
+        # Klondike configuration defaults
+        self._klondike_diff_index = 0
+        self._klondike_draw_mode = 3
+
+        self._klondike_modal = GameOptionsModal(
+            "Klondike – Options",
+            "Start Klondike",
+            [
+                (self._klondike_difficulty_label, self._cycle_klondike_difficulty),
+                (self._klondike_draw_label, self._toggle_klondike_draw_mode),
+            ],
+        )
+
 
     def handle_event(self, e):
+        if self._active_modal is not None:
+            result = self._active_modal.handle_event(e)
+            if result == "start":
+                if self._active_modal_start is not None:
+                    self._active_modal_start()
+                return
+            if result == "close":
+                self._close_active_modal()
+                return
+            if result:
+                return
+
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
             mx,my = e.pos
             if self.b_klon.hovered((mx,my)):
-                from solitaire.modes.klondike import KlondikeOptionsScene
-                self.next_scene = KlondikeOptionsScene(self.app)
+                self._open_modal(self._klondike_modal, self._start_klondike_game)
             elif self.b_quit.hovered((mx,my)):
                 pygame.quit(); raise SystemExit
         elif e.type == pygame.KEYDOWN:
@@ -31,3 +65,43 @@ class MainMenuScene(C.Scene):
         mp = pygame.mouse.get_pos()
         for b in [self.b_klon, self.b_quit]:
             b.draw(screen, hover=b.hovered(mp))
+        if self._active_modal is not None:
+            self._active_modal.draw(screen)
+
+    # ------------------------------------------------------------------
+    # Modal helpers
+    def _open_modal(self, modal, start_callback):
+        self._active_modal = modal
+        self._active_modal_start = start_callback
+        modal.open()
+
+    def _close_active_modal(self):
+        if self._active_modal is not None:
+            self._active_modal.close()
+        self._active_modal = None
+        self._active_modal_start = None
+
+    # ------------------------------------------------------------------
+    # Klondike-specific helpers
+    def _klondike_difficulty_label(self):
+        return "Difficulty: " + KLONDIKE_DIFFICULTY_LABELS[self._klondike_diff_index]
+
+    def _klondike_draw_label(self):
+        return f"Draw: {self._klondike_draw_mode}"
+
+    def _cycle_klondike_difficulty(self):
+        self._klondike_diff_index = (self._klondike_diff_index + 1) % len(KLONDIKE_DIFFICULTY_LABELS)
+        self._klondike_modal.refresh()
+
+    def _toggle_klondike_draw_mode(self):
+        self._klondike_draw_mode = 1 if self._klondike_draw_mode == 3 else 3
+        self._klondike_modal.refresh()
+
+    def _start_klondike_game(self):
+        stock_cycles = KLONDIKE_STOCK_CYCLE_LIMITS[self._klondike_diff_index]
+        self.next_scene = KlondikeGameScene(
+            self.app,
+            draw_count=self._klondike_draw_mode,
+            stock_cycles=stock_cycles,
+        )
+        self._close_active_modal()


### PR DESCRIPTION
## Summary
- replace the old Klondike options scene with a reusable game options modal
- open the Klondike options modal from the main menu and launch the game with the selected settings
- add shared difficulty metadata for Klondike to feed the modal labels

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68da2fee38e88321990bf59f18eaa6bf