### PR TITLE
Fix Gate saved game load without animator

### DIFF
--- a/src/solitaire/modes/gate.py
+++ b/src/solitaire/modes/gate.py
@@ -132,6 +132,9 @@ class GateGameScene(C.Scene):
             help_action={"on_click": lambda: self.help.open(), "tooltip": "How to play"},
         )
 
+        # Shared animator for single-card moves (needed before loading saved games)
+        self.anim: M.CardAnimator = M.CardAnimator()
+
         self.compute_layout()
         if load_state:
             self._load_from_state(load_state)
@@ -145,8 +148,6 @@ class GateGameScene(C.Scene):
         self._last_click_pos = (0, 0)
         # Klondike-style peek controller (shows single hovered face-up card under delay)
         self.peek = M.PeekController(delay_ms=2000)
-        # Shared animator for single-card moves
-        self.anim: M.CardAnimator = M.CardAnimator()
         # Auto-complete state
         self._auto_complete_active = False
         # Vertical scrolling


### PR DESCRIPTION
## Summary
- initialize the Gate animator before attempting to load a saved game so restoring state can cancel animations safely

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dadd2eadd08321a80c8c176f202c68