### PR TITLE
Add quit confirmation options before leaving gameplay

### DIFF
--- a/src/solitaire/__main__.py
+++ b/src/solitaire/__main__.py
@@ -136,6 +136,14 @@ def main():
         dt = clock.tick(60) / 1000.0
         for e in pygame.event.get():
             if e.type == pygame.QUIT:
+                helper = getattr(scene, "ui_helper", None)
+                modal = getattr(helper, "menu_modal", None)
+                if modal and hasattr(modal, "has_pending_confirm"):
+                    try:
+                        if modal.has_pending_confirm():
+                            modal.accept_default_confirm()
+                    except Exception:
+                        pass
                 confirm_quit = True
                 continue
             elif e.type == pygame.VIDEORESIZE:


### PR DESCRIPTION
## Summary
- show a detailed confirmation when choosing Quit to Menu or Quit to Desktop, offering save and quit options
- generalize the game menu confirmation overlay to support multiple actions and reusable helpers
- auto-accept the default game menu confirm option when the window is closed so flows still return to the menu first

## Testing
- pytest tests/unit_tests/test_app_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68dade72bb848321ad18e9bc99bb16b2