### PR TITLE
Animate Monte Carlo compaction, add undo, and show game over prompt

### DIFF
--- a/src/solitaire/modes/monte_carlo.py
+++ b/src/solitaire/modes/monte_carlo.py
@@ -362,6 +362,9 @@ class MonteCarloGameScene(ScrollableSceneMixin, C.Scene):
         def can_undo() -> bool:
             return self.can_undo()
 
+        def can_save() -> bool:
+            return not self._is_busy()
+
         def save_and_exit() -> None:
             self._save_game(to_menu=True)
 
@@ -378,7 +381,11 @@ class MonteCarloGameScene(ScrollableSceneMixin, C.Scene):
             ),
             save_action=(
                 "Save&Exit",
-                {"on_click": save_and_exit, "tooltip": "Save progress and return to the main menu"},
+                {
+                    "on_click": save_and_exit,
+                    "enabled": can_save,
+                    "tooltip": "Save progress and return to the main menu",
+                },
             ),
             help_action={"on_click": lambda: self.help.open(), "tooltip": "How to play"},
             extra_actions=[


### PR DESCRIPTION
## Summary
- add an animated queue for Monte Carlo compacting and stock deals and wire it into the existing toolbar
- introduce an undo stack that records pair removals and expose it via a toolbar button and shortcut
- present a dedicated game-over prompt when a compacted tableau has no available matches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db194559148321980e6d5b66e19ced