### PR TITLE
Remove compaction animation in Monte Carlo mode

### DIFF
--- a/src/solitaire/modes/monte_carlo.py
+++ b/src/solitaire/modes/monte_carlo.py
@@ -932,28 +932,9 @@ class MonteCarloGameScene(ScrollableSceneMixin, C.Scene):
         self.message = ""
         self._undo_stack.clear()
 
-        layout, move_steps = self._simulate_compact_layout()
+        layout, _ = self._simulate_compact_layout()
         self._pending_layout_after_compact = layout
-
-        if move_steps:
-            for card, (sr, sc), (er, ec) in move_steps:
-                start_rect = self._cell_rect(sr, sc)
-                end_rect = self._cell_rect(er, ec)
-
-                def _clear_source(r: int = sr, c: int = sc) -> None:
-                    if 0 <= r < self.rows and 0 <= c < self.cols:
-                        self.tableau[r][c] = None
-
-                self._queue_move(
-                    card,
-                    (start_rect.x, start_rect.y),
-                    (end_rect.x, end_rect.y),
-                    on_start=_clear_source,
-                    dur_ms=220,
-                )
-            self._set_post_queue_callback(self._apply_compacted_layout_and_fill)
-        else:
-            self._apply_compacted_layout_and_fill()
+        self._apply_compacted_layout_and_fill()
 
     def _has_matching_pairs(self) -> bool:
         for row in range(self.rows):


### PR DESCRIPTION
## Summary
- stop queuing animated moves for Monte Carlo tableau compaction so cards snap into place
- retain the animated stock refill by immediately applying the compacted layout and triggering the fill sequence

## Testing
- pytest tests/unit_tests/test_app_flow.py -k monte

------
https://chatgpt.com/codex/tasks/task_e_68db36e334f08321bc3a0367bb7e2fcf