### PR TITLE
Keep hint actions out of the game menu modal

### DIFF
--- a/src/solitaire/modes/base_scene.py
+++ b/src/solitaire/modes/base_scene.py
@@ -269,7 +269,7 @@ class ModeUIHelper:
         register("Restart", restart_action, shortcut=pygame.K_r, store_key="restart")
         register("Undo", undo_action, shortcut=pygame.K_u)
         register("Auto", auto_action, shortcut=pygame.K_a)
-        register("Hint", hint_action, shortcut=pygame.K_h, store_key="hint")
+        register("Hint", hint_action, shortcut=pygame.K_h)
         register("Save", save_action, shortcut=pygame.K_s, store_key="save")
         register("Help", help_action, store_key="help")
 
@@ -293,7 +293,6 @@ class ModeUIHelper:
             restart_action=stored.get("restart"),
             help_action=stored.get("help"),
             save_action=stored.get("save"),
-            hint_action=stored.get("hint"),
         )
 
         return make_toolbar(actions, **kwargs)

--- a/src/solitaire/modes/monte_carlo.py
+++ b/src/solitaire/modes/monte_carlo.py
@@ -411,7 +411,7 @@ class MonteCarloGameScene(ScrollableSceneMixin, C.Scene):
                     },
                 )
             ],
-            toolbar_kwargs={"primary_labels": ("Compact", "Undo")},
+            toolbar_kwargs={"primary_labels": ("Compact", "Undo", "Hint")},
         )
 
         self.compute_layout()

--- a/src/solitaire/ui.py
+++ b/src/solitaire/ui.py
@@ -379,7 +379,6 @@ class GameMenuModal:
         restart_action: Optional[Tuple[str, Mapping[str, Any]]] = None,
         help_action: Optional[Tuple[str, Mapping[str, Any]]] = None,
         save_action: Optional[Tuple[str, Mapping[str, Any]]] = None,
-        hint_action: Optional[Tuple[str, Mapping[str, Any]]] = None,
     ) -> None:
         self.helper = helper
         self.visible = False
@@ -392,7 +391,6 @@ class GameMenuModal:
             "restart": restart_action,
             "help": help_action,
             "save": save_action,
-            "hint": hint_action,
         }
         self._layout_dirty = True
         self._confirm_state: Optional[Dict[str, Any]] = None
@@ -406,8 +404,6 @@ class GameMenuModal:
             specs.append(("new", "New Game"))
         if self._actions.get("restart"):
             specs.append(("restart", "Restart Game"))
-        if self._actions.get("hint"):
-            specs.append(("hint", "Hint"))
         specs.append(("options", "Game Options"))
         if self._actions.get("help"):
             specs.append(("help", "Help"))
@@ -419,7 +415,7 @@ class GameMenuModal:
 
         for key, label in specs:
             enabled_fn: Optional[Callable[[], bool]] = None
-            if key in ("new", "restart", "hint", "help", "save"):
+            if key in ("new", "restart", "help", "save"):
                 entry = self._actions.get(key)
                 if entry is None:
                     continue
@@ -436,6 +432,14 @@ class GameMenuModal:
             self._buttons.append(button)
             self._button_keys.append(key)
         self._layout_dirty = True
+
+    def remove_action(self, key: str) -> None:
+        if key not in self._actions:
+            return
+        if self._actions[key] is None:
+            return
+        self._actions[key] = None
+        self._build_buttons()
 
     def relayout(self) -> None:
         self._layout_dirty = True
@@ -544,8 +548,6 @@ class GameMenuModal:
                 )
             else:
                 self._execute_entry(entry)
-        elif key == "hint":
-            self._execute_entry(self._actions.get("hint"))
         elif key == "help":
             self._execute_entry(self._actions.get("help"))
         elif key == "save":


### PR DESCRIPTION
## Summary
- stop the shared game menu modal from accepting or rendering hint actions so hint controls stay in the play area
- simplify Monte Carlo setup now that the modal never exposes a hint entry
- update the toolbar helper to only persist modal entries that are still used

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db488ebd4083218ae4c01ed1dc834d