### PR TITLE
Ensure hint button appears on toolbar for hint-capable modes

### DIFF
--- a/src/solitaire/ui.py
+++ b/src/solitaire/ui.py
@@ -349,6 +349,10 @@ def make_toolbar(
     menu_button_tooltip: Optional[str] = None
     visible_labels = set(primary_labels or ())
 
+    hint_cfg = actions.get("Hint")
+    if hint_cfg and callable(hint_cfg.get("on_click")):
+        visible_labels.add("Hint")
+
     for label, cfg in actions.items():
         on_click = cfg.get("on_click")
         if not callable(on_click):


### PR DESCRIPTION
## Summary
- stop the shared game menu modal from accepting or rendering hint actions so hint controls stay in the play area
- simplify Monte Carlo setup now that the modal never exposes a hint entry
- update the toolbar helper to only persist modal entries that are still used
- ensure hint-capable modes display a toolbar Hint button

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db4dc5775c8321ad501b881f969b03