### PR TITLE
Add British Square game mode

### DIFF
--- a/src/solitaire/assets/help/help_en.json
+++ b/src/solitaire/assets/help/help_en.json
@@ -27,6 +27,21 @@
     ],
     "max_width": 880
   },
+  "british_square": {
+    "title": "British Square — How to Play",
+    "lines": [
+      "Goal: Build each suited foundation from Ace up to King, place the second King on top, then build back down to Ace.",
+      "Setup: Two standard decks are shuffled together. Four rows of four face-up cards form the tableau. Remaining cards become the face-down stock; the waste starts empty.",
+      "Layout: Tableau piles form a centred 4×4 grid. A single column of foundations — Spades, Hearts, Diamonds, Clubs — sits one card-width to the right. Stock and waste piles rest to the left.",
+      "Moves to foundations: Drag or double-click any exposed tableau or waste top card that matches the next rank required for its suited foundation (A→K, the second K, then K→A).",
+      "Tableau building: Move one card at a time between tableau piles when it matches suit and is exactly one rank above or below the destination top card. The first move sets that pile's build direction until the pile is emptied.",
+      "Empty tableau piles immediately refill from the waste top card when available; otherwise draw the next stock card (turned face-up) to fill the vacancy.",
+      "Stock & waste: Click the stock to deal one card face-up to the waste. Waste cards may play to tableau piles (respecting suit/direction) or foundations.",
+      "Controls: The toolbar provides New, Restart, Undo, Hint, Auto (once stock and waste are empty), Help, and Save & Exit. Dragging near edges pans the table when layouts exceed the screen.",
+      "End: Win when all four foundations complete both ascending and descending sequences. If the stock and waste are empty and no tableau moves remain, the game is lost."
+    ],
+    "max_width": 900
+  },
   "beleaguered_castle": {
     "title": "Beleaguered Castle - How to Play",
     "lines": [

--- a/src/solitaire/modes/base_scene.py
+++ b/src/solitaire/modes/base_scene.py
@@ -95,6 +95,12 @@ _GAME_METADATA: Tuple[GameMetadata, ...] = (
         section="Packers",
     ),
     GameMetadata(
+        key="british_square",
+        label="British\nSquare",
+        icon_filename="icon_british_square.png",
+        section="Packers",
+    ),
+    GameMetadata(
         key="big_ben",
         label="Big Ben",
         icon_filename="icon_big_ben.png",
@@ -138,7 +144,20 @@ GAME_REGISTRY: Dict[str, GameMetadata] = {meta.key: meta for meta in _GAME_METAD
 
 # Section definitions preserve the ordering from the original main menu.
 GAME_SECTIONS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
-    ("Packers", ("klondike", "freecell", "gate", "demon", "duchess", "chameleon", "beleaguered_castle", "yukon")),
+    (
+        "Packers",
+        (
+            "klondike",
+            "freecell",
+            "gate",
+            "demon",
+            "duchess",
+            "chameleon",
+            "beleaguered_castle",
+            "yukon",
+            "british_square",
+        ),
+    ),
     ("Builders", ("big_ben", "golf", "monte_carlo", "pyramid", "tripeaks")),
     ("Other", ("accordion", "bowling_solitaire")),
 )

--- a/src/solitaire/modes/british_square.py
+++ b/src/solitaire/modes/british_square.py
@@ -1,0 +1,1030 @@
+"""British Square solitaire implementation."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import pygame
+
+from solitaire import common as C
+from solitaire import mechanics as M
+from solitaire.help_data import create_modal_help
+from solitaire.modes.base_scene import ModeUIHelper
+
+
+_SAVE_FILENAME = "british_square_save.json"
+
+
+def _bs_dir() -> str:
+    return C.project_saves_dir("british_square")
+
+
+def _bs_save_path() -> str:
+    return os.path.join(_bs_dir(), _SAVE_FILENAME)
+
+
+def _safe_write_json(path: str, data: Any) -> None:
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+    except Exception:
+        pass
+
+
+def _safe_read_json(path: str) -> Optional[Any]:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def _clear_saved_game() -> None:
+    try:
+        if os.path.isfile(_bs_save_path()):
+            os.remove(_bs_save_path())
+    except Exception:
+        pass
+
+
+def has_saved_game() -> bool:
+    state = _safe_read_json(_bs_save_path())
+    if not isinstance(state, dict):
+        return False
+    if state.get("completed"):
+        return False
+    return True
+
+
+def load_saved_game() -> Optional[Dict[str, Any]]:
+    state = _safe_read_json(_bs_save_path())
+    if not isinstance(state, dict):
+        return None
+    if state.get("completed"):
+        return None
+    return state
+
+
+_FOUNDATION_SEQUENCE: Tuple[int, ...] = tuple(list(range(1, 14)) + [13] + list(range(12, 0, -1)))
+
+
+@dataclass
+class _DragState:
+    cards: List[C.Card]
+    src_kind: str
+    src_index: int
+    offset: Tuple[int, int]
+
+
+class BritishSquareGameScene(C.Scene):
+    """Game scene for British Square."""
+
+    def __init__(self, app, load_state: Optional[Dict[str, Any]] = None):
+        super().__init__(app)
+
+        # Core piles
+        self.foundations: List[C.Pile] = [C.Pile(0, 0) for _ in range(4)]
+        self.foundation_suits: List[int] = [0, 1, 2, 3]  # Spades, Hearts, Diamonds, Clubs
+        self.foundation_progress: List[int] = [0, 0, 0, 0]
+        self.tableau: List[C.Pile] = [C.Pile(0, 0, fan_y=max(26, int(C.CARD_H * 0.22))) for _ in range(16)]
+        self.tableau_dirs: List[int] = [0 for _ in range(16)]  # 0 = not set, 1 = building up, -1 = down
+        self.stock_pile: C.Pile = C.Pile(0, 0)
+        self.waste_pile: C.Pile = C.Pile(0, 0)
+
+        # Interaction helpers
+        self.undo_mgr = C.UndoManager()
+        self.animator = M.CardAnimator()
+        self.drag_state: Optional[_DragState] = None
+        self.message: str = ""
+        self.completed: bool = False
+        self._game_over: bool = False
+
+        # Scrolling and peeking
+        self.scroll_x = 0
+        self.scroll_y = 0
+        self.drag_pan = M.DragPanController()
+        self._drag_vscroll = False
+        self._drag_hscroll = False
+        self._vscroll_geom: Optional[Tuple[int, int, int, int, int]] = None
+        self._hscroll_geom: Optional[Tuple[int, int, int, int, int]] = None
+        self._vscroll_drag_offset = 0
+        self._hscroll_drag_offset = 0
+        self.peek = M.PeekController(delay_ms=1200)
+        self.edge_pan = M.EdgePanDuringDrag(edge_margin_px=28, top_inset_px=getattr(C, "TOP_BAR_H", 60))
+
+        # Hint + Auto-complete state
+        self.hint_targets: Optional[List[Tuple[str, int]]] = None
+        self.hint_expires_at: int = 0
+        self.auto_active = False
+        self.auto_last_time = 0
+        self.auto_interval_ms = 200
+
+        # End-of-game modal state
+        self._result_modal: Optional[Dict[str, Any]] = None
+
+        # UI helper / toolbar
+        self.ui_helper = ModeUIHelper(self, game_id="british_square")
+
+        def can_undo() -> bool:
+            return self.undo_mgr.can_undo()
+
+        self.toolbar = self.ui_helper.build_toolbar(
+            new_action={"on_click": self.deal_new},
+            restart_action={"on_click": self.restart, "tooltip": "Restart current deal"},
+            undo_action={"on_click": self.undo, "enabled": can_undo, "tooltip": "Undo last move"},
+            hint_action={"on_click": self.show_hint, "enabled": lambda: not self.auto_active},
+            auto_action={
+                "on_click": self.start_autocomplete,
+                "enabled": self.can_autocomplete,
+                "tooltip": "Automatically play remaining cards",
+            },
+            save_action=(
+                "Save&Exit",
+                {
+                    "on_click": lambda: self._save_game(to_menu=True),
+                    "tooltip": "Save game and return to menu",
+                },
+            ),
+            help_action={"on_click": lambda: self.help.open(), "tooltip": "How to play"},
+        )
+
+        # Help modal (raises if entry missing – ensures help text provided)
+        self.help = create_modal_help("british_square")
+
+        # Layout / setup
+        self.compute_layout()
+        if load_state:
+            self._load_from_state(load_state)
+            self.undo_mgr = C.UndoManager()
+            self.push_undo()  # baseline undo for loaded state
+        else:
+            self.deal_new()
+
+        self._initial_snapshot = self.record_snapshot()
+        self._last_click_time = 0
+        self._last_click_pos = (0, 0)
+
+    # ------------------------------------------------------------------
+    # Layout & scrolling helpers
+    # ------------------------------------------------------------------
+    def compute_layout(self) -> None:
+        gap_x = getattr(C, "CARD_GAP_X", max(18, C.CARD_W // 6))
+        gap_y = getattr(C, "CARD_GAP_Y", max(20, C.CARD_H // 6))
+
+        top_bar = getattr(C, "TOP_BAR_H", 60)
+        top_y = top_bar + C.CARD_H // 2
+
+        cols = 4
+        rows = 4
+        tableau_width = cols * C.CARD_W + (cols - 1) * gap_x
+        left = (C.SCREEN_W - tableau_width) // 2
+
+        for r in range(rows):
+            for c in range(cols):
+                idx = r * cols + c
+                pile = self.tableau[idx]
+                pile.x = left + c * (C.CARD_W + gap_x)
+                pile.y = top_y + r * (C.CARD_H + gap_y)
+                pile.fan_y = max(28, int(C.CARD_H * 0.22))
+
+        # Foundations column to the right with full card width gap
+        rightmost = left + (cols - 1) * (C.CARD_W + gap_x)
+        foundation_x = rightmost + C.CARD_W * 2
+        for i, pile in enumerate(self.foundations):
+            pile.x = foundation_x
+            pile.y = top_y + i * (C.CARD_H + gap_y)
+
+        # Stock / waste to the left of tableau for balance
+        stock_gap = max(gap_x * 2, int(C.CARD_W * 0.8))
+        stock_x = left - stock_gap - C.CARD_W
+        stock_y = top_y
+        self.stock_pile.x, self.stock_pile.y = stock_x, stock_y
+        self.waste_pile.x = stock_x
+        self.waste_pile.y = stock_y + C.CARD_H + gap_y
+
+        self._clamp_scroll_xy()
+
+    def _pile_bounds(self, pile: C.Pile, max_len: Optional[int] = None) -> Tuple[int, int, int, int]:
+        count = len(pile.cards)
+        if max_len is not None:
+            count = max(count, max_len)
+        if count <= 0:
+            count = 1
+        xs: List[int] = []
+        ys: List[int] = []
+        for idx in range(count):
+            r = pile.rect_for_index(idx)
+            xs.extend([r.x, r.x + C.CARD_W])
+            ys.extend([r.y, r.y + C.CARD_H])
+        return min(xs), max(xs), min(ys), max(ys)
+
+    def _content_bounds(self) -> Tuple[int, int, int, int]:
+        piles = [self.stock_pile, self.waste_pile] + self.tableau + self.foundations
+        bounds = [self._pile_bounds(p) for p in piles]
+        lefts, rights, tops, bottoms = zip(*bounds)
+        pad = 18
+        return min(lefts) - pad, max(rights) + pad, min(tops) - pad, max(bottoms) + pad
+
+    def _scroll_limits(self) -> Tuple[int, int, int, int]:
+        left, right, top, bottom = self._content_bounds()
+        margin = 20
+        top_bar = getattr(C, "TOP_BAR_H", 60)
+        max_sx = margin - left
+        min_sx = min(0, C.SCREEN_W - right - margin)
+        max_sy = top_bar + margin - top
+        min_sy = min(0, C.SCREEN_H - bottom - margin)
+        return min_sx, max_sx, min_sy, max_sy
+
+    def _clamp_scroll_xy(self) -> None:
+        min_sx, max_sx, min_sy, max_sy = self._scroll_limits()
+        if max_sx < min_sx:
+            max_sx = min_sx
+        if max_sy < min_sy:
+            max_sy = min_sy
+        self.scroll_x = max(min(self.scroll_x, max_sx), min_sx)
+        self.scroll_y = max(min(self.scroll_y, max_sy), min_sy)
+
+    def _vertical_scrollbar(self):
+        min_sx, max_sx, min_sy, max_sy = self._scroll_limits()
+        if max_sy <= min_sy:
+            return None
+        track_x = C.SCREEN_W - 12
+        track_y = getattr(C, "TOP_BAR_H", 60)
+        track_h = C.SCREEN_H - track_y - 10
+        if track_h <= 0:
+            return None
+        view_h = track_h
+        content_h = view_h + (max_sy - min_sy)
+        thumb_h = max(30, int(view_h * (view_h / content_h)))
+        rel = 0 if max_sy == min_sy else (self.scroll_y - min_sy) / float(max_sy - min_sy)
+        thumb_y = track_y + int((view_h - thumb_h) * rel)
+        return track_x, track_y, track_h, thumb_y, thumb_h
+
+    def _horizontal_scrollbar(self):
+        min_sx, max_sx, min_sy, max_sy = self._scroll_limits()
+        if max_sx <= min_sx:
+            return None
+        track_y = C.SCREEN_H - 12
+        track_x = 10
+        track_w = C.SCREEN_W - 20
+        if track_w <= 0:
+            return None
+        view_w = track_w
+        content_w = view_w + (max_sx - min_sx)
+        thumb_w = max(30, int(view_w * (view_w / content_w)))
+        rel = 0 if max_sx == min_sx else (self.scroll_x - min_sx) / float(max_sx - min_sx)
+        thumb_x = track_x + int((view_w - thumb_w) * rel)
+        return track_x, track_y, track_w, thumb_x, thumb_w
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def record_snapshot(self) -> Dict[str, Any]:
+        def cap_pile(p: C.Pile) -> List[Tuple[int, int, bool]]:
+            return [(c.suit, c.rank, c.face_up) for c in p.cards]
+
+        return {
+            "foundations": [cap_pile(p) for p in self.foundations],
+            "progress": list(self.foundation_progress),
+            "tableau": [cap_pile(p) for p in self.tableau],
+            "dirs": list(self.tableau_dirs),
+            "stock": cap_pile(self.stock_pile),
+            "waste": cap_pile(self.waste_pile),
+            "message": self.message,
+            "completed": self.completed,
+            "game_over": self._game_over,
+            "scroll_x": self.scroll_x,
+            "scroll_y": self.scroll_y,
+        }
+
+    def restore_snapshot(self, snap: Dict[str, Any]) -> None:
+        def mk(seq: Iterable[Sequence[Any]]) -> List[C.Card]:
+            result: List[C.Card] = []
+            for suit, rank, face_up in seq:
+                card = C.Card(suit, rank, face_up)
+                result.append(card)
+            return result
+
+        for i, pile in enumerate(self.foundations):
+            pile.cards = mk(snap.get("foundations", [])[i]) if i < len(snap.get("foundations", [])) else []
+        self.foundation_progress = list(snap.get("progress", [0, 0, 0, 0]))[:4]
+        if len(self.foundation_progress) < 4:
+            self.foundation_progress += [0] * (4 - len(self.foundation_progress))
+        for i, pile in enumerate(self.tableau):
+            pile.cards = mk(snap.get("tableau", [])[i]) if i < len(snap.get("tableau", [])) else []
+        self.tableau_dirs = list(snap.get("dirs", [0] * 16))[:16]
+        if len(self.tableau_dirs) < 16:
+            self.tableau_dirs += [0] * (16 - len(self.tableau_dirs))
+        self.stock_pile.cards = mk(snap.get("stock", []))
+        self.waste_pile.cards = mk(snap.get("waste", []))
+        self.message = snap.get("message", "")
+        self.completed = bool(snap.get("completed", False))
+        self._game_over = bool(snap.get("game_over", False))
+        self.scroll_x = int(snap.get("scroll_x", 0))
+        self.scroll_y = int(snap.get("scroll_y", 0))
+        self._clamp_scroll_xy()
+        self._result_modal = None
+
+    def push_undo(self) -> None:
+        snap = self.record_snapshot()
+
+        def _undo(snapshot=snap):
+            self.restore_snapshot(snapshot)
+
+        self.undo_mgr.push(_undo)
+
+    def undo(self) -> None:
+        if self.undo_mgr.can_undo():
+            self.undo_mgr.undo()
+            self.peek.cancel()
+            self.hint_targets = None
+            self.auto_active = False
+            self._game_over = False
+            self._result_modal = None
+
+    def restart(self) -> None:
+        if hasattr(self, "_initial_snapshot") and self._initial_snapshot:
+            self.restore_snapshot(self._initial_snapshot)
+            self.undo_mgr = C.UndoManager()
+            self.push_undo()
+            self.completed = False
+            self._game_over = False
+            self.auto_active = False
+            self._result_modal = None
+
+    def _save_game(self, *, to_menu: bool = False) -> None:
+        state = self.record_snapshot()
+        state["completed"] = self.completed
+        try:
+            _safe_write_json(_bs_save_path(), state)
+        finally:
+            if to_menu:
+                self.ui_helper.goto_main_menu()
+
+    def _load_from_state(self, state: Dict[str, Any]) -> None:
+        self.restore_snapshot(state)
+
+    # ------------------------------------------------------------------
+    # Dealing & stock logic
+    # ------------------------------------------------------------------
+    def deal_new(self) -> None:
+        deck: List[C.Card] = []
+        for _ in range(2):
+            for suit in range(4):
+                for rank in range(1, 14):
+                    deck.append(C.Card(suit, rank, face_up=False))
+        random.shuffle(deck)
+
+        for pile in self.tableau:
+            pile.cards.clear()
+        for pile in self.foundations:
+            pile.cards.clear()
+        self.stock_pile.cards.clear()
+        self.waste_pile.cards.clear()
+        self.foundation_progress = [0, 0, 0, 0]
+        self.tableau_dirs = [0] * 16
+        self.completed = False
+        self._game_over = False
+        self.message = ""
+        self.auto_active = False
+        self._result_modal = None
+        self.hint_targets = None
+
+        cols = 4
+        rows = 4
+        for r in range(rows):
+            for c in range(cols):
+                idx = r * cols + c
+                card = deck.pop()
+                card.face_up = True
+                self.tableau[idx].cards.append(card)
+
+        for card in deck:
+            card.face_up = False
+        self.stock_pile.cards = deck
+        self.waste_pile.cards = []
+
+        self.undo_mgr = C.UndoManager()
+        self.push_undo()
+        self._initial_snapshot = self.record_snapshot()
+        _clear_saved_game()
+
+    def _draw_from_stock(self) -> bool:
+        if not self.stock_pile.cards:
+            return False
+        card = self.stock_pile.cards.pop()
+        card.face_up = True
+        self.waste_pile.cards.append(card)
+        return True
+
+    # ------------------------------------------------------------------
+    # Game rule helpers
+    # ------------------------------------------------------------------
+    def _foundation_index_for_suit(self, suit: int) -> int:
+        try:
+            return self.foundation_suits.index(suit)
+        except ValueError:
+            return 0
+
+    def _can_place_on_foundation(self, card: C.Card, fi: int) -> bool:
+        if card.suit != self.foundation_suits[fi]:
+            return False
+        progress = self.foundation_progress[fi]
+        if progress >= len(_FOUNDATION_SEQUENCE):
+            return False
+        expected_rank = _FOUNDATION_SEQUENCE[progress]
+        return card.rank == expected_rank
+
+    def _advance_foundation(self, card: C.Card, fi: int) -> None:
+        self.foundations[fi].cards.append(card)
+        self.foundation_progress[fi] += 1
+        if self.foundation_progress[fi] >= len(_FOUNDATION_SEQUENCE):
+            self.foundation_progress[fi] = len(_FOUNDATION_SEQUENCE)
+
+    def _reset_tableau_dir(self, idx: int) -> None:
+        if not self.tableau[idx].cards:
+            self.tableau_dirs[idx] = 0
+
+    def _set_tableau_dir(self, idx: int, moving: C.Card, target: C.Card) -> bool:
+        direction = 1 if moving.rank == target.rank + 1 else -1 if moving.rank == target.rank - 1 else 0
+        if direction == 0:
+            return False
+        current = self.tableau_dirs[idx]
+        if current == 0:
+            self.tableau_dirs[idx] = direction
+            return True
+        return current == direction
+
+    def _can_place_on_tableau(self, card: C.Card, idx: int) -> bool:
+        pile = self.tableau[idx]
+        if not pile.cards:
+            return False
+        top = pile.cards[-1]
+        if top.suit != card.suit:
+            return False
+        direction = self.tableau_dirs[idx]
+        if direction == 0:
+            return abs(card.rank - top.rank) == 1
+        if direction > 0:
+            return card.rank == top.rank + 1
+        return card.rank == top.rank - 1
+
+    def _fill_empty_piles(self) -> None:
+        for idx, pile in enumerate(self.tableau):
+            if pile.cards:
+                continue
+            replacement = None
+            if self.waste_pile.cards:
+                replacement = self.waste_pile.cards.pop()
+            elif self.stock_pile.cards:
+                replacement = self.stock_pile.cards.pop()
+                replacement.face_up = True
+            if replacement:
+                replacement.face_up = True
+                pile.cards.append(replacement)
+                self.tableau_dirs[idx] = 0
+
+    def _try_move_to_foundation(self, src_kind: str, src_index: int) -> bool:
+        if src_kind == "tableau":
+            pile = self.tableau[src_index]
+            if not pile.cards:
+                return False
+            card = pile.cards[-1]
+        elif src_kind == "waste":
+            if not self.waste_pile.cards:
+                return False
+            card = self.waste_pile.cards[-1]
+        else:
+            return False
+        fi = self._foundation_index_for_suit(card.suit)
+        if not self._can_place_on_foundation(card, fi):
+            return False
+
+        self.push_undo()
+        if src_kind == "tableau":
+            pile.cards.pop()
+            self._reset_tableau_dir(src_index)
+        else:
+            self.waste_pile.cards.pop()
+        self._advance_foundation(card, fi)
+        self._fill_empty_piles()
+        self._check_for_completion()
+        return True
+
+    def _check_for_completion(self) -> None:
+        if all(progress == len(_FOUNDATION_SEQUENCE) for progress in self.foundation_progress):
+            self.completed = True
+            self._game_over = True
+            self.message = "You won!"
+            self._open_result_modal(win=True)
+
+    def _check_for_loss(self) -> None:
+        if self.completed:
+            return
+        if self.stock_pile.cards or self.waste_pile.cards:
+            return
+        if any(p.cards for p in self.tableau):
+            for idx, pile in enumerate(self.tableau):
+                if not pile.cards:
+                    continue
+                card = pile.cards[-1]
+                if self._can_place_on_foundation(card, self._foundation_index_for_suit(card.suit)):
+                    return
+                for other_idx, other in enumerate(self.tableau):
+                    if other_idx == idx or not other.cards:
+                        continue
+                    top = other.cards[-1]
+                    if top.suit != card.suit:
+                        continue
+                    direction = self.tableau_dirs[other_idx]
+                    if direction == 0 and abs(card.rank - top.rank) == 1:
+                        return
+                    if direction > 0 and card.rank == top.rank + 1:
+                        return
+                    if direction < 0 and card.rank == top.rank - 1:
+                        return
+        self._game_over = True
+        self.message = "No more moves. You lose."
+        self._open_result_modal(win=False)
+
+    def _open_result_modal(self, *, win: bool) -> None:
+        if self._result_modal:
+            return
+        self.auto_active = False
+        self.hint_targets = None
+        self._result_modal = {
+            "win": win,
+            "message": "You won! Start a new game?" if win else "No more moves. Start a new game?",
+            "buttons": [
+                {"label": "Yes", "action": "new", "rect": None},
+                {"label": "No", "action": "menu", "rect": None},
+            ],
+        }
+
+    def can_autocomplete(self) -> bool:
+        if self.auto_active:
+            return True
+        if self._result_modal:
+            return False
+        if self.stock_pile.cards or self.waste_pile.cards:
+            return False
+        return self._is_auto_win_state()
+
+    def _is_auto_win_state(self) -> bool:
+        pending_cards: Dict[int, List[int]] = {suit: [] for suit in range(4)}
+        for pile in self.tableau:
+            for card in pile.cards:
+                pending_cards[card.suit].append(card.rank)
+        for suit in range(4):
+            pending_cards[suit].sort()
+
+        progress = list(self.foundation_progress)
+        remaining_sequences = []
+        for suit in range(4):
+            seq = list(_FOUNDATION_SEQUENCE[progress[suit]:])
+            remaining_sequences.append((suit, seq))
+
+        temp = {s: list(ranks) for s, ranks in pending_cards.items()}
+        for suit, seq in remaining_sequences:
+            for rank in seq:
+                if not temp[suit]:
+                    return False
+                if rank not in temp[suit]:
+                    return False
+                temp[suit].remove(rank)
+        return True
+
+    def start_autocomplete(self) -> None:
+        if self._result_modal or not self.can_autocomplete():
+            return
+        self.auto_active = True
+        self.auto_last_time = 0
+
+    def _auto_play_step(self) -> None:
+        if not self.auto_active:
+            return
+        if self._result_modal:
+            self.auto_active = False
+            return
+        now = pygame.time.get_ticks()
+        if now - self.auto_last_time < self.auto_interval_ms:
+            return
+        self.auto_last_time = now
+        moved = False
+        # Try tableau tops first, then waste
+        for idx, pile in enumerate(self.tableau):
+            if not pile.cards:
+                continue
+            card = pile.cards[-1]
+            fi = self._foundation_index_for_suit(card.suit)
+            if self._can_place_on_foundation(card, fi):
+                self.push_undo()
+                pile.cards.pop()
+                self._reset_tableau_dir(idx)
+                self._advance_foundation(card, fi)
+                moved = True
+                break
+        if not moved and self.waste_pile.cards:
+            card = self.waste_pile.cards[-1]
+            fi = self._foundation_index_for_suit(card.suit)
+            if self._can_place_on_foundation(card, fi):
+                self.push_undo()
+                self.waste_pile.cards.pop()
+                self._advance_foundation(card, fi)
+                moved = True
+        if moved:
+            self._fill_empty_piles()
+            self._check_for_completion()
+            if self.completed:
+                self.auto_active = False
+        else:
+            self.auto_active = False
+
+    # ------------------------------------------------------------------
+    # Hint logic
+    # ------------------------------------------------------------------
+    def show_hint(self) -> None:
+        if self.auto_active or self._result_modal:
+            return
+        self.hint_targets = None
+        now = pygame.time.get_ticks()
+
+        # Moves to foundation
+        for idx, pile in enumerate(self.tableau):
+            if not pile.cards:
+                continue
+            card = pile.cards[-1]
+            fi = self._foundation_index_for_suit(card.suit)
+            if self._can_place_on_foundation(card, fi):
+                self.hint_targets = [("tableau", idx)]
+                self.hint_expires_at = now + 2500
+                return
+        if self.waste_pile.cards:
+            card = self.waste_pile.cards[-1]
+            fi = self._foundation_index_for_suit(card.suit)
+            if self._can_place_on_foundation(card, fi):
+                self.hint_targets = [("waste", 0)]
+                self.hint_expires_at = now + 2500
+                return
+
+        # Tableau moves
+        for src_idx, src in enumerate(self.tableau):
+            if not src.cards:
+                continue
+            card = src.cards[-1]
+            for dst_idx, dst in enumerate(self.tableau):
+                if src_idx == dst_idx:
+                    continue
+                if not dst.cards:
+                    continue
+                if self._can_place_on_tableau(card, dst_idx):
+                    self.hint_targets = [("tableau", src_idx), ("tableau", dst_idx)]
+                    self.hint_expires_at = now + 2500
+                    return
+        if self.waste_pile.cards:
+            card = self.waste_pile.cards[-1]
+            for dst_idx, dst in enumerate(self.tableau):
+                if not dst.cards:
+                    continue
+                if self._can_place_on_tableau(card, dst_idx):
+                    self.hint_targets = [("waste", 0), ("tableau", dst_idx)]
+                    self.hint_expires_at = now + 2500
+                    return
+
+    def _maybe_expire_hint(self) -> None:
+        if self.hint_targets and pygame.time.get_ticks() > self.hint_expires_at:
+            self.hint_targets = None
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+    def handle_event(self, event) -> None:
+        if self._result_modal:
+            if self._handle_result_modal_event(event):
+                return
+        if getattr(self, "help", None) and self.help.visible:
+            if self.help.handle_event(event):
+                return
+            if event.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEMOTION, pygame.KEYDOWN, pygame.MOUSEWHEEL):
+                return
+        if self.ui_helper.handle_menu_event(event):
+            return
+        if self.toolbar.handle_event(event):
+            return
+        if self.ui_helper.handle_shortcuts(event):
+            return
+        if event.type == pygame.QUIT:
+            self.app.running = False
+            return
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            self.ui_helper.toggle_menu_modal()
+            return
+        if self.drag_pan.handle_event(event, target=self, clamp=self._clamp_scroll_xy):
+            self.peek.cancel()
+            return
+        if event.type == pygame.MOUSEWHEEL:
+            self.scroll_y += event.y * 60
+            self.scroll_x += event.x * 40
+            self._clamp_scroll_xy()
+            self.peek.cancel()
+            return
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            self._on_mouse_down(event.pos)
+        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+            self._on_mouse_up(event.pos)
+        elif event.type == pygame.MOUSEMOTION:
+            self._on_mouse_motion(event.pos, event.rel)
+
+    def _screen_to_world(self, pos: Tuple[int, int]) -> Tuple[int, int]:
+        return pos[0] - self.scroll_x, pos[1] - self.scroll_y
+
+    def _on_mouse_down(self, pos: Tuple[int, int]) -> None:
+        if self.animator.active:
+            return
+        self.hint_targets = None
+        world = self._screen_to_world(pos)
+
+        # Stock click
+        if self.stock_pile.hit(world) is not None:
+            if self.stock_pile.cards:
+                self.push_undo()
+                self._draw_from_stock()
+            return
+
+        # Waste drag
+        if self.waste_pile.cards:
+            hit = self.waste_pile.hit(world)
+            if hit is not None and hit >= len(self.waste_pile.cards) - 1:
+                now = pygame.time.get_ticks()
+                if now - self._last_click_time < 350 and (abs(world[0] - self._last_click_pos[0]) < 6 and abs(world[1] - self._last_click_pos[1]) < 6):
+                    if self._try_move_to_foundation("waste", 0):
+                        self._fill_empty_piles()
+                        self._check_for_completion()
+                        self._check_for_loss()
+                        return
+                self.drag_state = _DragState(
+                    cards=[self.waste_pile.cards[-1]],
+                    src_kind="waste",
+                    src_index=0,
+                    offset=(world[0] - self.waste_pile.x, world[1] - self.waste_pile.y),
+                )
+                self._last_click_time = now
+                self._last_click_pos = world
+                return
+
+        # Tableau drag
+        for idx, pile in enumerate(self.tableau):
+            hit = pile.hit(world)
+            if hit is None:
+                continue
+            if hit == -1:
+                continue
+            if hit != len(pile.cards) - 1:
+                continue
+            card = pile.cards[-1]
+            self.drag_state = _DragState(
+                cards=[card],
+                src_kind="tableau",
+                src_index=idx,
+                offset=(world[0] - pile.x, world[1] - pile.y),
+            )
+            # Double-click detection for quick foundation move
+            now = pygame.time.get_ticks()
+            if now - self._last_click_time < 350 and (abs(world[0] - self._last_click_pos[0]) < 6 and abs(world[1] - self._last_click_pos[1]) < 6):
+                if self._try_move_to_foundation("tableau", idx):
+                    self.drag_state = None
+                    self._fill_empty_piles()
+                    self._check_for_completion()
+                    self._check_for_loss()
+                    return
+            self._last_click_time = pygame.time.get_ticks()
+            self._last_click_pos = world
+            return
+
+        # Foundation double-click (no drag)
+        for fi, pile in enumerate(self.foundations):
+            hit = pile.hit(world)
+            if hit is None:
+                continue
+            if pile.cards:
+                card = pile.cards[-1]
+                self.message = f"Foundation: {C.RANK_TO_TEXT[card.rank]}{C.SUITS[card.suit]}"
+            return
+
+    def _on_mouse_up(self, pos: Tuple[int, int]) -> None:
+        if not self.drag_state:
+            return
+        world = self._screen_to_world(pos)
+        drag = self.drag_state
+        self.drag_state = None
+
+        card = drag.cards[-1]
+        if drag.src_kind == "tableau":
+            origin = self.tableau[drag.src_index]
+        else:
+            origin = self.waste_pile
+
+        # Attempt foundation placement first
+        for fi, pile in enumerate(self.foundations):
+            rect = pygame.Rect(pile.x, pile.y, C.CARD_W, C.CARD_H)
+            if rect.collidepoint(world):
+                if self._can_place_on_foundation(card, fi):
+                    self.push_undo()
+                    origin.cards.pop()
+                    if drag.src_kind == "tableau":
+                        self._reset_tableau_dir(drag.src_index)
+                    self._advance_foundation(card, fi)
+                    self._fill_empty_piles()
+                    self._check_for_completion()
+                    self._check_for_loss()
+                    return
+
+        # Tableau drop
+        for idx, pile in enumerate(self.tableau):
+            rect = pygame.Rect(pile.x, pile.y, C.CARD_W, C.CARD_H + max(0, (len(pile.cards) - 1) * pile.fan_y))
+            if rect.collidepoint(world):
+                if self._can_place_on_tableau(card, idx) and self._set_tableau_dir(idx, card, pile.cards[-1]):
+                    self.push_undo()
+                    origin.cards.pop()
+                    pile.cards.append(card)
+                    if drag.src_kind == "tableau":
+                        self._reset_tableau_dir(drag.src_index)
+                    self._fill_empty_piles()
+                    self._check_for_completion()
+                    self._check_for_loss()
+                    return
+
+        # No valid move – leave card in its original pile
+
+    def _on_mouse_motion(self, pos: Tuple[int, int], rel: Tuple[int, int]) -> None:
+        world = self._screen_to_world(pos)
+        if self.drag_state:
+            self.edge_pan.on_mouse_motion(pos, rel)
+        else:
+            self.edge_pan.reset()
+        piles_for_peek = [self.waste_pile] + self.tableau
+        self.peek.on_motion_over_piles(piles_for_peek, world)
+
+    # ------------------------------------------------------------------
+    # Update & draw
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:
+        self._maybe_expire_hint()
+        self._auto_play_step()
+        self.edge_pan.update(self)
+        if not self.drag_state:
+            self.drag_pan.update(self)
+
+    def draw(self, screen) -> None:
+        screen.fill(C.TABLE_BG)
+
+        # Draw piles
+        all_piles = [
+            (self.stock_pile, "Stock"),
+            (self.waste_pile, "Waste"),
+        ]
+        for idx in range(16):
+            all_piles.append((self.tableau[idx], ""))
+        for pile, _ in all_piles:
+            self._draw_pile(screen, pile)
+        for pile in self.foundations:
+            self._draw_pile(screen, pile)
+
+        # Draw dragged card on top
+        if self.drag_state:
+            card = self.drag_state.cards[-1]
+            mx, my = pygame.mouse.get_pos()
+            world_x = mx - self.scroll_x
+            world_y = my - self.scroll_y
+            dx, dy = self.drag_state.offset
+            surf = C.get_card_surface(card)
+            screen.blit(surf, (world_x - dx + self.scroll_x, world_y - dy + self.scroll_y))
+
+        # Draw hint overlay
+        if self.hint_targets:
+            overlay = pygame.Surface((C.CARD_W, C.CARD_H), pygame.SRCALPHA)
+            pygame.draw.rect(overlay, (255, 255, 0, 80), overlay.get_rect(), border_radius=C.CARD_RADIUS)
+            for kind, index in self.hint_targets:
+                if kind == "tableau":
+                    pile = self.tableau[index]
+                else:
+                    pile = self.waste_pile
+                screen.blit(overlay, (pile.x + self.scroll_x, pile.y + self.scroll_y))
+
+        # Scrollbars
+        vbar = self._vertical_scrollbar()
+        if vbar:
+            track_x, track_y, track_h, thumb_y, thumb_h = vbar
+            pygame.draw.rect(screen, (40, 40, 40), (track_x, track_y, 6, track_h), border_radius=3)
+            pygame.draw.rect(screen, (200, 200, 200), (track_x, thumb_y, 6, thumb_h), border_radius=3)
+        hbar = self._horizontal_scrollbar()
+        if hbar:
+            track_x, track_y, track_w, thumb_x, thumb_w = hbar
+            pygame.draw.rect(screen, (40, 40, 40), (track_x, track_y, track_w, 6), border_radius=3)
+            pygame.draw.rect(screen, (200, 200, 200), (thumb_x, track_y, thumb_w, 6), border_radius=3)
+
+        # Top bar + message
+        title = "British Square"
+        extra = self.message
+        self.draw_top_bar(screen, title, extra)
+        self.toolbar.draw(screen)
+        if getattr(self, "help", None) and self.help.visible:
+            self.help.draw(screen)
+        self.ui_helper.draw_menu_modal(screen)
+
+        # Result modal overlay (drawn after UI)
+        if self._result_modal:
+            self._draw_result_modal(screen)
+
+        # Animator (on top of everything else)
+        if self.animator.active:
+            self.animator.draw(screen, self.scroll_x, self.scroll_y)
+
+        # Peek overlay
+        if not self._result_modal:
+            self.peek.maybe_activate(pygame.time.get_ticks())
+            if self.peek.overlay:
+                card, px, py = self.peek.overlay
+                surf = C.get_card_surface(card)
+                screen.blit(surf, (px + self.scroll_x, py + self.scroll_y))
+
+    def _draw_pile(self, screen, pile: C.Pile) -> None:
+        if not pile.cards:
+            pygame.draw.rect(
+                screen,
+                (255, 255, 255, 50),
+                (pile.x + self.scroll_x, pile.y + self.scroll_y, C.CARD_W, C.CARD_H),
+                width=2,
+                border_radius=C.CARD_RADIUS,
+            )
+            return
+        for idx, card in enumerate(pile.cards):
+            rect = pile.rect_for_index(idx)
+            surf = C.get_card_surface(card)
+            screen.blit(surf, (rect.x + self.scroll_x, rect.y + self.scroll_y))
+
+    def _draw_result_modal(self, screen) -> None:
+        modal_rect = pygame.Rect(0, 0, 420, 220)
+        modal_rect.center = (C.SCREEN_W // 2, C.SCREEN_H // 2)
+        overlay = pygame.Surface((C.SCREEN_W, C.SCREEN_H), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 140))
+        screen.blit(overlay, (0, 0))
+        pygame.draw.rect(screen, (245, 245, 245), modal_rect, border_radius=12)
+        pygame.draw.rect(screen, (40, 40, 45), modal_rect, width=2, border_radius=12)
+        message = self._result_modal.get("message", "") if self._result_modal else ""
+        font = C.FONT_UI or pygame.font.SysFont(pygame.font.get_default_font(), 26, bold=True)
+        text_surf = font.render(message, True, (30, 30, 40))
+        screen.blit(text_surf, (modal_rect.centerx - text_surf.get_width() // 2, modal_rect.y + 56))
+
+        buttons = self._result_modal.get("buttons", []) if self._result_modal else []
+        btn_width = 140
+        btn_height = 50
+        gap = 24
+        total_width = len(buttons) * btn_width + max(0, len(buttons) - 1) * gap
+        start_x = modal_rect.centerx - total_width // 2
+        btn_y = modal_rect.bottom - btn_height - 36
+        font_btn = C.FONT_UI or pygame.font.SysFont(pygame.font.get_default_font(), 24, bold=True)
+        for idx, button in enumerate(buttons):
+            rect = pygame.Rect(start_x + idx * (btn_width + gap), btn_y, btn_width, btn_height)
+            button["rect"] = rect
+            pygame.draw.rect(screen, (230, 230, 235), rect, border_radius=10)
+            pygame.draw.rect(screen, (60, 60, 65), rect, width=2, border_radius=10)
+            label = button.get("label", "")
+            label_surf = font_btn.render(label, True, (20, 20, 30))
+            screen.blit(label_surf, (rect.centerx - label_surf.get_width() // 2, rect.centery - label_surf.get_height() // 2))
+
+    def _handle_result_modal_event(self, event) -> bool:
+        if event.type == pygame.QUIT:
+            self.app.running = False
+            return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            buttons = self._result_modal.get("buttons", []) if self._result_modal else []
+            for button in buttons:
+                rect = button.get("rect")
+                if rect and rect.collidepoint(event.pos):
+                    action = button.get("action")
+                    if action == "new":
+                        self.deal_new()
+                    else:
+                        self.ui_helper.goto_main_menu()
+                    self._result_modal = None
+                    return True
+            return True
+        if event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_SPACE, pygame.K_y):
+                self.deal_new()
+                self._result_modal = None
+                return True
+            if event.key in (pygame.K_ESCAPE, pygame.K_n):
+                self.ui_helper.goto_main_menu()
+                self._result_modal = None
+                return True
+        if event.type in (pygame.MOUSEMOTION, pygame.MOUSEBUTTONUP):
+            return True
+        return True
+

--- a/src/solitaire/scenes/menu_options.py
+++ b/src/solitaire/scenes/menu_options.py
@@ -732,6 +732,46 @@ class KlondikeController(GameOptionsController):
         return {"b_start": "start", "b_back": "cancel", "b_continue": "resume"}
 
 
+# --- British Square ---------------------------------------------------
+
+from solitaire.modes import british_square as british_square_mode
+
+
+class BritishSquareController(GameOptionsController):
+    def _has_save(self) -> bool:
+        return british_square_mode.has_saved_game()
+
+    def buttons(self) -> Sequence[ButtonState]:
+        return [
+            ButtonState("cancel", "Cancel", variant="cancel"),
+            ButtonState("resume", "Resume", enabled=self._has_save()),
+            ButtonState("start", "Start", variant="primary"),
+        ]
+
+    def handle_button(self, key: str) -> ActionResult:
+        if key == "cancel":
+            return ActionResult(close_modal=True)
+        if key == "start":
+            try:
+                british_square_mode._clear_saved_game()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            self.menu_scene.next_scene = british_square_mode.BritishSquareGameScene(self.app)
+            return ActionResult(close_modal=True)
+        if key == "resume" and self._has_save():
+            state = british_square_mode.load_saved_game()
+            if state:
+                self.menu_scene.next_scene = british_square_mode.BritishSquareGameScene(
+                    self.app,
+                    load_state=state,
+                )
+                return ActionResult(close_modal=True)
+        return ActionResult(close_modal=False)
+
+    def compatibility_actions(self) -> Dict[str, str]:
+        return {"b_start": "start", "b_back": "cancel", "b_continue": "resume"}
+
+
 # --- Pyramid ---------------------------------------------------------
 
 from solitaire.modes import pyramid as pyramid_mode
@@ -946,6 +986,7 @@ CONTROLLER_REGISTRY = {
     "accordion": AccordionController,
     "beleaguered_castle": BeleagueredCastleController,
     "big_ben": BigBenController,
+    "british_square": BritishSquareController,
     "bowling_solitaire": BowlingSolitaireController,
     "chameleon": ChameleonController,
     "demon": DemonController,


### PR DESCRIPTION
## Summary
- add British Square to the Packets section metadata and options controller so it can be launched from the main menu
- implement the BritishSquareGameScene with two-deck dealing, direction-locked tableau moves, automatic refills, hints, auto-complete, and end-of-game modal flow
- provide in-game help text for British Square outlining setup, moves, controls, and win/loss conditions

## Testing
- python -m compileall src/solitaire/modes/british_square.py

------
https://chatgpt.com/codex/tasks/task_e_68db86f80e0c8321bc38a1da5cda4fa5