### PR TITLE
Adjust British Square layout and add refill control

### DIFF
--- a/src/solitaire/mechanics.py
+++ b/src/solitaire/mechanics.py
@@ -22,6 +22,8 @@ class CardAnimator:
         self._on_complete: Optional[Callable[[], None]] = None
         self._flip_mid: bool = False
         self._flipped: bool = False
+        self._from_use_scroll: bool = True
+        self._to_use_scroll: bool = True
 
     def start_move(
         self,
@@ -31,6 +33,9 @@ class CardAnimator:
         dur_ms: int = 300,
         on_complete: Optional[Callable[[], None]] = None,
         flip_mid: bool = False,
+        *,
+        from_use_scroll: bool = True,
+        to_use_scroll: bool = True,
     ):
         self._card = card
         self._from = from_xy
@@ -41,6 +46,8 @@ class CardAnimator:
         self._flip_mid = bool(flip_mid)
         self._flipped = False
         self.active = True
+        self._from_use_scroll = from_use_scroll
+        self._to_use_scroll = to_use_scroll
 
     def cancel(self):
         self.active = False
@@ -68,21 +75,25 @@ class CardAnimator:
         # Interpolate
         sx, sy = self._from
         tx, ty = self._to
-        x = int(sx + (tx - sx) * t)
-        y = int(sy + (ty - sy) * t)
+        from_sx = sx + (scroll_x if self._from_use_scroll else 0)
+        from_sy = sy + (scroll_y if self._from_use_scroll else 0)
+        to_sx = tx + (scroll_x if self._to_use_scroll else 0)
+        to_sy = ty + (scroll_y if self._to_use_scroll else 0)
+        x = int(from_sx + (to_sx - from_sx) * t)
+        y = int(from_sy + (to_sy - from_sy) * t)
         if self._flip_mid:
             if t >= 0.5 and not self._flipped:
                 self._card.face_up = True
                 self._flipped = True
             if t < 0.5:
                 back = C.get_back_surface()
-                surface.blit(back, (x + scroll_x, y + scroll_y))
+                surface.blit(back, (x, y))
             else:
                 surf = C.get_card_surface(self._card)
-                surface.blit(surf, (x + scroll_x, y + scroll_y))
+                surface.blit(surf, (x, y))
         else:
             surf = C.get_card_surface(self._card)
-            surface.blit(surf, (x + scroll_x, y + scroll_y))
+            surface.blit(surf, (x, y))
 
 
 def auto_move_first_ace(

--- a/src/solitaire/modes/british_square.py
+++ b/src/solitaire/modes/british_square.py
@@ -14,6 +14,7 @@ from solitaire import common as C
 from solitaire import mechanics as M
 from solitaire.help_data import create_modal_help
 from solitaire.modes.base_scene import ModeUIHelper
+from solitaire.ui import Button
 
 
 _SAVE_FILENAME = "british_square_save.json"
@@ -123,9 +124,11 @@ class BritishSquareGameScene(C.Scene):
         self.auto_active = False
         self.auto_last_time = 0
         self.auto_interval_ms = 200
+        self._stock_hint_active = False
 
         # End-of-game modal state
         self._result_modal: Optional[Dict[str, Any]] = None
+        self._refill_button: Optional[Button] = None
 
         # UI helper / toolbar
         self.ui_helper = ModeUIHelper(self, game_id="british_square")
@@ -159,7 +162,18 @@ class BritishSquareGameScene(C.Scene):
                 },
             ),
             help_action={"on_click": lambda: self.help.open(), "tooltip": "How to play"},
+            extra_actions=[
+                (
+                    "Refill",
+                    {
+                        "on_click": self._on_click_refill,
+                        "tooltip": "Draw from stock",
+                    },
+                )
+            ],
+            toolbar_kwargs={"primary_labels": ("Refill", "Undo", "Hint")},
         )
+        self._refill_button = self.toolbar.get_button("Refill")
 
         # Help modal (raises if entry missing – ensures help text provided)
         self.help = create_modal_help("british_square")
@@ -202,10 +216,15 @@ class BritishSquareGameScene(C.Scene):
 
         # Foundations column to the right with full card width gap
         rightmost = left + (cols - 1) * (C.CARD_W + gap_x)
-        foundation_x = rightmost + C.CARD_W * 2
+        foundation_gap_x = max(gap_x, C.CARD_W // 2)
+        foundation_cols = 2
+        foundation_rows = max(1, (len(self.foundations) + foundation_cols - 1) // foundation_cols)
+        foundation_start_x = rightmost + C.CARD_W + foundation_gap_x
         for i, pile in enumerate(self.foundations):
-            pile.x = foundation_x
-            pile.y = top_y + i * (C.CARD_H + gap_y)
+            col = i // foundation_rows
+            row = i % foundation_rows
+            pile.x = foundation_start_x + col * (C.CARD_W + foundation_gap_x)
+            pile.y = stock_y + row * (C.CARD_H + gap_y)
 
         # Stock / waste to the left of tableau for balance
         stock_gap = max(gap_x * 2, int(C.CARD_W * 0.8))
@@ -232,7 +251,7 @@ class BritishSquareGameScene(C.Scene):
         return min(xs), max(xs), min(ys), max(ys)
 
     def _content_bounds(self) -> Tuple[int, int, int, int]:
-        piles = [self.stock_pile, self.waste_pile] + self.tableau + self.foundations
+        piles = [self.stock_pile, self.waste_pile] + self.tableau
         bounds = [self._pile_bounds(p) for p in piles]
         lefts, rights, tops, bottoms = zip(*bounds)
         pad = 18
@@ -256,6 +275,11 @@ class BritishSquareGameScene(C.Scene):
             max_sy = min_sy
         self.scroll_x = max(min(self.scroll_x, max_sx), min_sx)
         self.scroll_y = max(min(self.scroll_y, max_sy), min_sy)
+
+    def _scroll_offset_for_kind(self, kind: str) -> Tuple[int, int]:
+        if kind in {"stock", "waste", "tableau"}:
+            return self.scroll_x, self.scroll_y
+        return 0, 0
 
     def _vertical_scrollbar(self):
         min_sx, max_sx, min_sy, max_sy = self._scroll_limits()
@@ -350,7 +374,7 @@ class BritishSquareGameScene(C.Scene):
         if self.undo_mgr.can_undo():
             self.undo_mgr.undo()
             self.peek.cancel()
-            self.hint_targets = None
+            self._clear_hint_targets()
             self.auto_active = False
             self._game_over = False
             self._result_modal = None
@@ -364,6 +388,7 @@ class BritishSquareGameScene(C.Scene):
             self._game_over = False
             self.auto_active = False
             self._result_modal = None
+            self._clear_hint_targets()
 
     def _save_game(self, *, to_menu: bool = False) -> None:
         state = self.record_snapshot()
@@ -376,11 +401,13 @@ class BritishSquareGameScene(C.Scene):
 
     def _load_from_state(self, state: Dict[str, Any]) -> None:
         self.restore_snapshot(state)
+        self._clear_hint_targets()
 
     # ------------------------------------------------------------------
     # Dealing & stock logic
     # ------------------------------------------------------------------
     def deal_new(self) -> None:
+        self._clear_hint_targets()
         deck: List[C.Card] = []
         for _ in range(2):
             for suit in range(4):
@@ -401,7 +428,6 @@ class BritishSquareGameScene(C.Scene):
         self.message = ""
         self.auto_active = False
         self._result_modal = None
-        self.hint_targets = None
 
         cols = 4
         rows = 4
@@ -563,6 +589,7 @@ class BritishSquareGameScene(C.Scene):
             (dest_rect.x, dest_rect.y),
             dur_ms=260,
             on_complete=_on_complete,
+            to_use_scroll=False,
         )
         return True
 
@@ -606,7 +633,7 @@ class BritishSquareGameScene(C.Scene):
         if self._result_modal:
             return
         self.auto_active = False
-        self.hint_targets = None
+        self._clear_hint_targets()
         self._result_modal = {
             "win": win,
             "message": "You won! Start a new game?" if win else "No more moves. Start a new game?",
@@ -703,7 +730,7 @@ class BritishSquareGameScene(C.Scene):
     def show_hint(self) -> None:
         if self.auto_active or self._result_modal:
             return
-        self.hint_targets = None
+        self._clear_hint_targets()
         now = pygame.time.get_ticks()
 
         # Moves to foundation
@@ -748,9 +775,39 @@ class BritishSquareGameScene(C.Scene):
                     self.hint_expires_at = now + 2500
                     return
 
+        if self.stock_pile.cards:
+            self.hint_targets = [("stock", 0)]
+            self._set_stock_hint_active(True)
+            self.hint_expires_at = now + 2500
+            return
+
     def _maybe_expire_hint(self) -> None:
         if self.hint_targets and pygame.time.get_ticks() > self.hint_expires_at:
-            self.hint_targets = None
+            self._clear_hint_targets()
+
+    def _set_stock_hint_active(self, active: bool) -> None:
+        if self._stock_hint_active == active:
+            return
+        self._stock_hint_active = active
+        if self._refill_button:
+            self._refill_button.set_highlight(active)
+
+    def _clear_hint_targets(self) -> None:
+        self.hint_targets = None
+        self._set_stock_hint_active(False)
+
+    def _handle_stock_action(self) -> None:
+        self._clear_hint_targets()
+        if not self.stock_pile.cards:
+            return
+        self.push_undo()
+        if self._draw_from_stock():
+            self.peek.cancel()
+
+    def _on_click_refill(self) -> None:
+        if self.animator.active:
+            return
+        self._handle_stock_action()
 
     # ------------------------------------------------------------------
     # Event handling
@@ -798,14 +855,12 @@ class BritishSquareGameScene(C.Scene):
     def _on_mouse_down(self, pos: Tuple[int, int]) -> None:
         if self.animator.active:
             return
-        self.hint_targets = None
+        self._clear_hint_targets()
         world = self._screen_to_world(pos)
 
         # Stock click
         if self.stock_pile.hit(world) is not None:
-            if self.stock_pile.cards:
-                self.push_undo()
-                self._draw_from_stock()
+            self._handle_stock_action()
             return
 
         # Waste drag
@@ -857,7 +912,7 @@ class BritishSquareGameScene(C.Scene):
 
         # Foundation double-click (no drag)
         for fi, pile in enumerate(self.foundations):
-            hit = pile.hit(world)
+            hit = pile.hit(pos)
             if hit is None:
                 continue
             if pile.cards:
@@ -882,7 +937,7 @@ class BritishSquareGameScene(C.Scene):
         # Attempt foundation placement first
         for fi, pile in enumerate(self.foundations):
             rect = pygame.Rect(pile.x, pile.y, C.CARD_W, C.CARD_H)
-            if rect.collidepoint(world):
+            if rect.collidepoint(pos):
                 if self._can_place_on_foundation(card, fi):
                     self.push_undo()
                     origin.cards.pop()
@@ -960,9 +1015,14 @@ class BritishSquareGameScene(C.Scene):
             for kind, index in self.hint_targets:
                 if kind == "tableau":
                     pile = self.tableau[index]
-                else:
+                elif kind == "waste":
                     pile = self.waste_pile
-                screen.blit(overlay, (pile.x + self.scroll_x, pile.y + self.scroll_y))
+                elif kind == "stock":
+                    pile = self.stock_pile
+                else:
+                    continue
+                ox, oy = self._scroll_offset_for_kind(kind)
+                screen.blit(overlay, (pile.x + ox, pile.y + oy))
 
         # Scrollbars
         vbar = self._vertical_scrollbar()
@@ -1013,11 +1073,12 @@ class BritishSquareGameScene(C.Scene):
             elif kind == "waste" and self.drag_state.src_kind == "waste":
                 skip_top = True
         visible_count = len(pile.cards) - (1 if skip_top else 0)
+        ox, oy = self._scroll_offset_for_kind(kind)
         if visible_count <= 0:
             pygame.draw.rect(
                 screen,
                 (255, 255, 255, 50),
-                (pile.x + self.scroll_x, pile.y + self.scroll_y, C.CARD_W, C.CARD_H),
+                (pile.x + ox, pile.y + oy, C.CARD_W, C.CARD_H),
                 width=2,
                 border_radius=C.CARD_RADIUS,
             )
@@ -1027,7 +1088,7 @@ class BritishSquareGameScene(C.Scene):
                     continue
                 rect = pile.rect_for_index(idx_card)
                 surf = C.get_card_surface(card)
-                screen.blit(surf, (rect.x + self.scroll_x, rect.y + self.scroll_y))
+                screen.blit(surf, (rect.x + ox, rect.y + oy))
         if kind == "tableau":
             self._draw_tableau_indicators(screen, pile, index, skip_top)
 
@@ -1036,8 +1097,9 @@ class BritishSquareGameScene(C.Scene):
     ) -> None:
         if not hasattr(self, "tableau_info_font"):
             return
-        base_x = pile.x + self.scroll_x
-        base_y = pile.y + self.scroll_y
+        ox, oy = self._scroll_offset_for_kind("tableau")
+        base_x = pile.x + ox
+        base_y = pile.y + oy
         display_count = max(0, len(pile.cards) - (1 if skip_top else 0))
 
         count_text = self.tableau_info_font.render(str(display_count), True, (255, 255, 255))

--- a/src/solitaire/ui.py
+++ b/src/solitaire/ui.py
@@ -19,6 +19,7 @@ BTN_BG_DISABLED = (200, 200, 205)
 BTN_BORDER = (160, 160, 170)
 BTN_TEXT = (30, 30, 35)
 BTN_TEXT_DISABLED = (120, 120, 130)
+BTN_HIGHLIGHT = (255, 235, 120)
 MENU_PANEL_BG = (245, 245, 250)
 
 FONT = pygame.font.SysFont("Segoe UI", 18)
@@ -50,6 +51,7 @@ class Button:
         self.min_width = min_width
         self.rect = pygame.Rect(0, 0, 0, 0)
         self._hover = False
+        self._highlight = False
 
         text_w = FONT.render(self.label, True, BTN_TEXT).get_width()
         w = max(self.min_width, text_w + DEFAULT_BUTTON_PADDING_X * 2)
@@ -70,9 +72,18 @@ class Button:
                 return True
         return False
 
+    def set_highlight(self, active: bool) -> None:
+        self._highlight = active
+
+    def is_highlighted(self) -> bool:
+        return self._highlight
+
     def draw(self, surface: pygame.Surface):
         enabled = self.is_enabled()
         bg = BTN_BG_DISABLED if not enabled else (BTN_BG_HOVER if self._hover else BTN_BG)
+        if self._highlight:
+            highlight_rect = self.rect.inflate(10, 10)
+            pygame.draw.rect(surface, BTN_HIGHLIGHT, highlight_rect, border_radius=12)
         pygame.draw.rect(surface, bg, self.rect, border_radius=8)
         pygame.draw.rect(surface, BTN_BORDER, self.rect, width=1, border_radius=8)
         color = BTN_TEXT if enabled else BTN_TEXT_DISABLED
@@ -128,6 +139,12 @@ class Toolbar:
     def draw(self, surface: pygame.Surface):
         for b in self.buttons:
             b.draw(surface)
+
+    def get_button(self, label: str) -> Optional[Button]:
+        for b in self.buttons:
+            if getattr(b, "label", None) == label:
+                return b
+        return None
 
 class HamburgerMenuButton(Button):
     """Toolbar button that opens an in-game modal menu."""


### PR DESCRIPTION
## Summary
- keep British Square foundations anchored while adjusting layout so they align with the stock row
- add a toolbar refill button that mirrors stock clicks and tie hint highlighting to it
- support static foundations during scrolling by updating draw offsets and card animation handling

## Testing
- python -m compileall src/solitaire

------
https://chatgpt.com/codex/tasks/task_e_68dc82bc4f6c8321b08fefbca273f71b