### PR TITLE
Refine main menu layout with horizontal gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Solitaire Suite (Pygame)
 Overview
 - Simple Pygame-based solitaire suite including Klondike, FreeCell, and Pyramid.
 - Uses built-in vector drawing with optional image card assets bundled under `src/solitaire/assets`.
+- Main menu presents each game section as a four-column gallery that you cycle through with circular arrows; Big Ben now appears with the other Packers games.
 
 Requirements
 - Python 3.11+

--- a/src/solitaire/modes/base_scene.py
+++ b/src/solitaire/modes/base_scene.py
@@ -104,7 +104,7 @@ _GAME_METADATA: Tuple[GameMetadata, ...] = (
         key="big_ben",
         label="Big Ben",
         icon_filename="icon_big_ben.png",
-        section="Builders",
+        section="Packers",
     ),
     GameMetadata(
         key="british_blockade",
@@ -162,9 +162,10 @@ GAME_SECTIONS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
             "beleaguered_castle",
             "yukon",
             "british_square",
+            "big_ben",
         ),
     ),
-    ("Builders", ("big_ben", "british_blockade", "golf", "monte_carlo", "pyramid", "tripeaks")),
+    ("Builders", ("british_blockade", "golf", "monte_carlo", "pyramid", "tripeaks")),
     ("Other", ("accordion", "bowling_solitaire")),
 )
 

--- a/src/solitaire/scenes/menu.py
+++ b/src/solitaire/scenes/menu.py
@@ -322,10 +322,12 @@ class MainMenuScene(C.Scene):
     SECTION_BORDER = (0, 0, 0)
     SECTION_BORDER_RADIUS = 26
 
-    SCROLL_MIN_TOP = 140
-    SCROLL_BOTTOM_MARGIN = 80
-    SCROLLBAR_WIDTH = 14
-    SCROLL_STEP = 48
+    GRID_COLUMNS = 4
+    SECTION_TOP = 220
+    NAV_BUTTON_RADIUS = 42
+    NAV_BUTTON_GAP = 36
+    NAV_BUTTON_BG = (245, 245, 245)
+    NAV_BUTTON_BORDER = (65, 65, 70)
 
     def __init__(self, app, *, open_game_key: str | None = None):
         super().__init__(app)
@@ -366,6 +368,12 @@ class MainMenuScene(C.Scene):
             for entry in section["entries"]:
                 self._entry_lookup[entry.key] = entry
 
+        if self._pending_open_key:
+            for idx, section in enumerate(self._sections):
+                if any(entry.key == self._pending_open_key for entry in section["entries"]):
+                    self._section_index = idx
+                    break
+
         self._modal_rect = pygame.Rect(0, 0, 520, 360)
         self._modal_padding_top = 130
         self._modal_padding_bottom = 70
@@ -375,17 +383,12 @@ class MainMenuScene(C.Scene):
         self._modal_quit = C.Button("Quit Game", 0, 0, center=True)
         self._modal_buttons = [self._modal_settings, self._modal_back, self._modal_quit]
 
-        # Scroll state
-        self._scroll_offset = 0
-        self._max_scroll = 0
-        self._viewport_height = 0
-        self._content_start = self.SCROLL_MIN_TOP
-        self._content_total_height = 0
-        self._scroll_track_rect = pygame.Rect(0, 0, 0, 0)
-        self._scroll_thumb_rect = pygame.Rect(0, 0, 0, 0)
-        self._scroll_dragging = False
-        self._scroll_drag_anchor = 0
-        self._scroll_drag_start_offset = 0
+        # Section navigation state
+        self._section_index = 0
+        self._nav_left_rect = pygame.Rect(0, 0, 0, 0)
+        self._nav_right_rect = pygame.Rect(0, 0, 0, 0)
+        self._nav_hover_left = False
+        self._nav_hover_right = False
 
         self._prepare_assets()
         self.compute_layout()
@@ -436,59 +439,27 @@ class MainMenuScene(C.Scene):
 
     # --- layout --------------------------------------------------------
     def compute_layout(self):
-        sections_info = []
-        margin_x = min(self.SECTION_OUTER_MARGIN_X, max(20, (C.SCREEN_W - 640) // 4))
-        available_width = max(self.ICON_SIZE, C.SCREEN_W - margin_x * 2)
-
         for section in self._sections:
             entries = section["entries"]
-            columns = max(1, min(len(entries), (available_width + self.ICON_GAP) // (self.ICON_SIZE + self.ICON_GAP)))
+            columns = max(1, min(self.GRID_COLUMNS, len(entries)))
             rows = ceil(len(entries) / columns)
-            content_width = columns * self.ICON_SIZE + (columns - 1) * self.ICON_GAP
             max_label_height = max((entry.label_surf.get_height() if entry.label_surf else 0) for entry in entries)
             row_height = self.ICON_SIZE + self.LABEL_MARGIN + max_label_height
+            content_width = columns * self.ICON_SIZE + (columns - 1) * self.ICON_GAP
             content_height = rows * row_height + (rows - 1) * self.ICON_GAP
             title_surf: pygame.Surface = section["title_surf"]
             title_height = title_surf.get_height()
             section_width = content_width + self.SECTION_PADDING * 2
             section_height = content_height + self.SECTION_PADDING * 2 + title_height + self.SECTION_TITLE_GAP
-            sections_info.append({
-                "section": section,
-                "columns": columns,
-                "rows": rows,
-                "content_width": content_width,
-                "row_height": row_height,
-                "section_width": section_width,
-                "section_height": section_height,
-                "title_height": title_height,
-            })
 
-        total_height = sum(info["section_height"] for info in sections_info)
-        if sections_info:
-            total_height += self.SECTION_VERTICAL_GAP * (len(sections_info) - 1)
-
-        available_height = max(120, C.SCREEN_H - (self.SCROLL_MIN_TOP + self.SCROLL_BOTTOM_MARGIN))
-        if total_height <= available_height:
-            start_top = self.SCROLL_MIN_TOP + (available_height - total_height) // 2
-            self._max_scroll = 0
-            self._scroll_offset = 0
-        else:
-            start_top = self.SCROLL_MIN_TOP
-            self._max_scroll = total_height - available_height
-            self._scroll_offset = max(0, min(self._scroll_offset, self._max_scroll))
-        self._viewport_height = available_height
-        self._content_start = start_top
-        self._content_total_height = total_height
-
-        top = start_top
-        for info in sections_info:
-            section = info["section"]
             rect = section["rect"]
-            rect.size = (info["section_width"], info["section_height"])
+            rect.size = (section_width, section_height)
             rect.centerx = C.SCREEN_W // 2
-            rect.top = top
+            preferred_top = self.SECTION_TOP
+            max_top = max(40, C.SCREEN_H - section_height - 40)
+            rect.top = min(preferred_top, max_top)
 
-            title_rect = section["title_surf"].get_rect()
+            title_rect = title_surf.get_rect()
             title_rect.centerx = rect.centerx
             title_rect.top = rect.top + self.SECTION_PADDING
             section["title_rect"] = title_rect
@@ -496,9 +467,7 @@ class MainMenuScene(C.Scene):
             grid_left = rect.left + self.SECTION_PADDING
             grid_top = title_rect.bottom + self.SECTION_TITLE_GAP
 
-            columns = info["columns"]
-            row_height = info["row_height"]
-            for index, entry in enumerate(section["entries"]):
+            for index, entry in enumerate(entries):
                 col = index % columns
                 row = index // columns
                 x = grid_left + col * (self.ICON_SIZE + self.ICON_GAP)
@@ -507,15 +476,14 @@ class MainMenuScene(C.Scene):
                 entry.label_rect.centerx = entry.rect.centerx
                 entry.label_rect.top = entry.rect.bottom + self.LABEL_MARGIN
 
-            top = rect.bottom + self.SECTION_VERTICAL_GAP
+            section["columns"] = columns
+            section["rows"] = rows
 
         margin_x, margin_y = self._menu_margin
         self._menu_button_rect.topright = (C.SCREEN_W - margin_x, margin_y)
         self._modal_rect.center = (C.SCREEN_W // 2, C.SCREEN_H // 2)
         self._position_modal_buttons()
-        self._update_scrollbar_rects()
-        if not self._max_scroll:
-            self._scroll_dragging = False
+        self._update_nav_rects()
 
     def _position_modal_buttons(self):
         gap = self._modal_gap
@@ -532,40 +500,52 @@ class MainMenuScene(C.Scene):
             btn.rect.center = (cx, current_y + btn.rect.height // 2)
             current_y += btn.rect.height + gap
 
-    def _update_scrollbar_rects(self):
-        if self._viewport_height <= 0:
-            self._scroll_track_rect = pygame.Rect(0, 0, 0, 0)
-            self._scroll_thumb_rect = pygame.Rect(0, 0, 0, 0)
+    def _update_nav_rects(self):
+        size = self.NAV_BUTTON_RADIUS * 2
+        if not self._sections:
+            self._nav_left_rect = pygame.Rect(0, 0, 0, 0)
+            self._nav_right_rect = pygame.Rect(0, 0, 0, 0)
             return
-        track_x = C.SCREEN_W - self.SCROLLBAR_WIDTH - 32
-        self._scroll_track_rect = pygame.Rect(track_x, self._content_start, self.SCROLLBAR_WIDTH, self._viewport_height)
-        if self._max_scroll <= 0:
-            self._scroll_thumb_rect = pygame.Rect(track_x, self._content_start, self.SCROLLBAR_WIDTH, self._viewport_height)
-            return
-        ratio = min(1.0, self._viewport_height / float(self._content_total_height)) if self._content_total_height else 0
-        thumb_h = max(40, int(self._viewport_height * ratio))
-        thumb_h = min(self._viewport_height, thumb_h)
-        travel = max(1, self._viewport_height - thumb_h)
-        thumb_y = self._content_start + int((self._scroll_offset / self._max_scroll) * travel)
-        self._scroll_thumb_rect = pygame.Rect(track_x, thumb_y, self.SCROLLBAR_WIDTH, thumb_h)
 
-    def _scroll_by(self, delta: int):
-        if self._max_scroll <= 0:
-            self._scroll_offset = 0
-            return
-        self._scroll_offset = max(0, min(self._max_scroll, self._scroll_offset + delta))
-        self._update_scrollbar_rects()
+        index = max(0, min(self._section_index, len(self._sections) - 1))
+        self._section_index = index
+        rect = self._sections[index]["rect"]
 
-    def _to_content_pos(self, pos):
-        return pos[0], pos[1] + self._scroll_offset
+        center_y = rect.centery
+        left = pygame.Rect(0, 0, size, size)
+        right = pygame.Rect(0, 0, size, size)
+
+        left.centerx = max(self.NAV_BUTTON_RADIUS + 20, rect.left - self.NAV_BUTTON_GAP - self.NAV_BUTTON_RADIUS)
+        right.centerx = min(C.SCREEN_W - self.NAV_BUTTON_RADIUS - 20, rect.right + self.NAV_BUTTON_GAP + self.NAV_BUTTON_RADIUS)
+        left.centery = center_y
+        right.centery = center_y
+
+        self._nav_left_rect = left
+        self._nav_right_rect = right
+        self._nav_hover_left = False
+        self._nav_hover_right = False
+
+    def _change_section(self, delta: int) -> None:
+        if not self._sections:
+            return
+        new_index = max(0, min(len(self._sections) - 1, self._section_index + delta))
+        if new_index == self._section_index:
+            return
+        self._section_index = new_index
+        self._hover_entry = None
+        self._update_nav_rects()
 
     def get_entry_rect(self, key: str):
         entry = self._entry_lookup.get(key)
         if entry is None:
             return None
-        rect = entry.rect.copy()
-        rect.y -= self._scroll_offset
-        return rect
+        for idx, section in enumerate(self._sections):
+            if any(e.key == key for e in section["entries"]):
+                if idx != self._section_index:
+                    self._section_index = idx
+                    self._update_nav_rects()
+                break
+        return entry.rect.copy()
 
     # --- interaction ---------------------------------------------------
     def _open_game_modal(self, game_key: str, *, proxy=None) -> bool:
@@ -624,14 +604,6 @@ class MainMenuScene(C.Scene):
             return
 
     def handle_event(self, e):
-        if e.type == pygame.MOUSEWHEEL and not self._modal_open:
-            if self._max_scroll > 0:
-                self._scroll_by(-e.y * self.SCROLL_STEP)
-            return
-
-        if e.type == pygame.MOUSEBUTTONUP and e.button == 1:
-            self._scroll_dragging = False
-
         if self._options_modal is not None:
             should_close = False
             if e.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP, pygame.MOUSEMOTION, pygame.KEYDOWN):
@@ -647,50 +619,44 @@ class MainMenuScene(C.Scene):
             return
 
         if e.type == pygame.MOUSEMOTION:
-            if self._scroll_dragging and self._max_scroll > 0:
-                dy = e.pos[1] - self._scroll_drag_anchor
-                travel = max(1, self._viewport_height - self._scroll_thumb_rect.height)
-                ratio = dy / float(travel)
-                self._scroll_offset = max(0, min(self._max_scroll, self._scroll_drag_start_offset + ratio * self._max_scroll))
-                self._update_scrollbar_rects()
-                return
             self._menu_hover = self._menu_button_rect.collidepoint(e.pos)
+            left_enabled = self._section_index > 0
+            right_enabled = self._section_index < len(self._sections) - 1
+            self._nav_hover_left = left_enabled and self._nav_left_rect.collidepoint(e.pos)
+            self._nav_hover_right = right_enabled and self._nav_right_rect.collidepoint(e.pos)
             self._hover_entry = None
-            content_pos = self._to_content_pos(e.pos)
-            for section in self._sections:
+            if self._sections:
+                section = self._sections[self._section_index]
                 for entry in section["entries"]:
-                    if entry.rect.collidepoint(content_pos):
+                    if entry.rect.collidepoint(e.pos):
                         self._hover_entry = entry
                         break
-                if self._hover_entry is not None:
-                    break
             return
 
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
-            if self._max_scroll > 0 and self._scroll_thumb_rect.collidepoint(e.pos):
-                self._scroll_dragging = True
-                self._scroll_drag_anchor = e.pos[1]
-                self._scroll_drag_start_offset = self._scroll_offset
-                return
-            if self._max_scroll > 0 and self._scroll_track_rect.collidepoint(e.pos):
-                if e.pos[1] < self._scroll_thumb_rect.top:
-                    self._scroll_by(-self._viewport_height)
-                else:
-                    self._scroll_by(self._viewport_height)
-                return
             if self._menu_button_rect.collidepoint(e.pos):
                 self._modal_open = True
                 return
-            content_pos = self._to_content_pos(e.pos)
-            for section in self._sections:
+            if self._section_index > 0 and self._nav_left_rect.collidepoint(e.pos):
+                self._change_section(-1)
+                return
+            if self._section_index < len(self._sections) - 1 and self._nav_right_rect.collidepoint(e.pos):
+                self._change_section(1)
+                return
+            if self._sections:
+                section = self._sections[self._section_index]
                 for entry in section["entries"]:
-                    if entry.rect.collidepoint(content_pos):
+                    if entry.rect.collidepoint(e.pos):
                         self._activate_entry(entry)
                         return
         elif e.type == pygame.KEYDOWN:
             if e.key == pygame.K_ESCAPE:
                 from solitaire.scenes.title import TitleScene
                 self.next_scene = TitleScene(self.app)
+            elif e.key == pygame.K_LEFT:
+                self._change_section(-1)
+            elif e.key == pygame.K_RIGHT:
+                self._change_section(1)
 
     # --- drawing -------------------------------------------------------
     def _draw_menu_button(self, screen):
@@ -710,28 +676,51 @@ class MainMenuScene(C.Scene):
             pygame.draw.line(screen, line_color, (start_x, y), (start_x + line_width, y), 3)
 
     def _draw_sections(self, screen):
-        for section in self._sections:
-            rect = section["rect"].move(0, -self._scroll_offset)
-            if rect.bottom < 0 or rect.top > C.SCREEN_H:
-                continue
-            pygame.draw.rect(screen, self.SECTION_BG, rect, border_radius=self.SECTION_BORDER_RADIUS)
-            pygame.draw.rect(screen, self.SECTION_BORDER, rect, width=2, border_radius=self.SECTION_BORDER_RADIUS)
-            title_rect = section["title_rect"].move(0, -self._scroll_offset)
-            screen.blit(section["title_surf"], title_rect.topleft)
-            for entry in section["entries"]:
-                icon_rect = entry.rect.move(0, -self._scroll_offset)
-                label_rect = entry.label_rect.move(0, -self._scroll_offset)
-                screen.blit(entry.surface, icon_rect.topleft)
-                if entry.label_surf is not None:
-                    screen.blit(entry.label_surf, label_rect.topleft)
-
-    def _draw_scrollbar(self, screen):
-        if self._max_scroll <= 0:
+        if not self._sections:
             return
-        track = self._scroll_track_rect
-        thumb = self._scroll_thumb_rect
-        pygame.draw.rect(screen, (40, 40, 45), track, border_radius=6)
-        pygame.draw.rect(screen, (180, 180, 190), thumb, border_radius=6)
+        section = self._sections[self._section_index]
+        rect = section["rect"]
+        pygame.draw.rect(screen, self.SECTION_BG, rect, border_radius=self.SECTION_BORDER_RADIUS)
+        pygame.draw.rect(screen, self.SECTION_BORDER, rect, width=2, border_radius=self.SECTION_BORDER_RADIUS)
+        title_rect = section["title_rect"]
+        screen.blit(section["title_surf"], title_rect.topleft)
+        for entry in section["entries"]:
+            screen.blit(entry.surface, entry.rect.topleft)
+            if entry.label_surf is not None:
+                screen.blit(entry.label_surf, entry.label_rect.topleft)
+
+    def _draw_nav_button(self, screen, rect: pygame.Rect, direction: int, enabled: bool, hover: bool) -> None:
+        if rect.width <= 0 or rect.height <= 0 or not enabled and len(self._sections) <= 1:
+            return
+        bg = self.NAV_BUTTON_BG if enabled else (210, 210, 215)
+        if hover and enabled:
+            bg = (max(0, bg[0] - 10), max(0, bg[1] - 10), max(0, bg[2] - 10))
+        border = self.NAV_BUTTON_BORDER
+        pygame.draw.ellipse(screen, bg, rect)
+        pygame.draw.ellipse(screen, border, rect, width=3)
+
+        cx, cy = rect.center
+        arrow_size = rect.width // 3
+        arrow_color = border if enabled else (140, 140, 145)
+        if direction < 0:
+            points = [
+                (cx + arrow_size // 2, cy - arrow_size),
+                (cx - arrow_size // 2, cy),
+                (cx + arrow_size // 2, cy + arrow_size),
+            ]
+        else:
+            points = [
+                (cx - arrow_size // 2, cy - arrow_size),
+                (cx + arrow_size // 2, cy),
+                (cx - arrow_size // 2, cy + arrow_size),
+            ]
+        pygame.draw.polygon(screen, arrow_color, points)
+
+    def _draw_navigation(self, screen):
+        if len(self._sections) <= 1:
+            return
+        self._draw_nav_button(screen, self._nav_left_rect, -1, self._section_index > 0, self._nav_hover_left)
+        self._draw_nav_button(screen, self._nav_right_rect, 1, self._section_index < len(self._sections) - 1, self._nav_hover_right)
 
     def _draw_modal(self, screen):
         overlay = pygame.Surface((C.SCREEN_W, C.SCREEN_H), pygame.SRCALPHA)
@@ -752,7 +741,7 @@ class MainMenuScene(C.Scene):
         title = C.FONT_TITLE.render("Solitaire Suite", True, C.WHITE) if C.FONT_TITLE else pygame.font.SysFont(pygame.font.get_default_font(), 44, bold=True).render("Solitaire Suite", True, C.WHITE)
         screen.blit(title, (C.SCREEN_W // 2 - title.get_width() // 2, 110))
         self._draw_sections(screen)
-        self._draw_scrollbar(screen)
+        self._draw_navigation(screen)
         self._draw_menu_button(screen)
         if self._modal_open:
             self._draw_modal(screen)


### PR DESCRIPTION
## Summary
- Move Big Ben into the Packers section and update the README to reflect the new grouping.
- Rebuild the main menu as a horizontal gallery that shows one section at a time in a four-column grid with circular navigation arrows.
- Ensure menu helpers select the relevant section when opening games so external callers and tests interact with the right view.

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dead96d6408321904652ee01d49237