### PR TITLE
Add scrollable menu sections with consistent sizing

### DIFF
--- a/src/solitaire/scenes/menu.py
+++ b/src/solitaire/scenes/menu.py
@@ -323,12 +323,17 @@ class MainMenuScene(C.Scene):
     SECTION_BORDER_RADIUS = 26
 
     GRID_COLUMNS = 4
+    MIN_GRID_COLUMNS = 3
+    MIN_GRID_ROWS = 3
     SECTION_TOP = 220
     NAV_BUTTON_RADIUS = 42
     NAV_BUTTON_GAP = 36
     NAV_BUTTON_BG = (245, 245, 245)
     NAV_BUTTON_BORDER = (65, 65, 70)
     NAV_BUTTON_SCREEN_MARGIN = 20
+
+    SCROLLBAR_WIDTH = 12
+    SCROLLBAR_MARGIN = 12
 
     def __init__(self, app, *, open_game_key: str | None = None):
         super().__init__(app)
@@ -361,6 +366,11 @@ class MainMenuScene(C.Scene):
                     "rect": pygame.Rect(0, 0, 0, 0),
                     "title_surf": None,
                     "title_rect": pygame.Rect(0, 0, 0, 0),
+                    "viewport_rect": pygame.Rect(0, 0, 0, 0),
+                    "scroll_offset": 0,
+                    "scroll_max": 0,
+                    "row_stride": 0,
+                    "has_scroll": False,
                 }
             )
 
@@ -442,16 +452,25 @@ class MainMenuScene(C.Scene):
     def compute_layout(self):
         for section in self._sections:
             entries = section["entries"]
-            columns = max(1, min(self.GRID_COLUMNS, len(entries)))
-            rows = ceil(len(entries) / columns)
+            entry_count = len(entries)
+            columns = max(1, min(self.GRID_COLUMNS, entry_count)) if entry_count else 1
+            rows = ceil(entry_count / columns) if entry_count else 0
             max_label_height = max((entry.label_surf.get_height() if entry.label_surf else 0) for entry in entries)
             row_height = self.ICON_SIZE + self.LABEL_MARGIN + max_label_height
-            content_width = columns * self.ICON_SIZE + (columns - 1) * self.ICON_GAP
-            content_height = rows * row_height + (rows - 1) * self.ICON_GAP
+            row_stride = row_height + self.ICON_GAP
+
+            actual_width = columns * self.ICON_SIZE + max(0, columns - 1) * self.ICON_GAP if entry_count else 0
+            min_columns_width = self.MIN_GRID_COLUMNS * self.ICON_SIZE + max(0, self.MIN_GRID_COLUMNS - 1) * self.ICON_GAP
+            viewport_width = max(actual_width, min_columns_width)
+            viewport_height = self.MIN_GRID_ROWS * row_height + max(0, self.MIN_GRID_ROWS - 1) * self.ICON_GAP
+            actual_height = rows * row_height + max(0, rows - 1) * self.ICON_GAP if rows else 0
+            has_scroll = actual_height > viewport_height
+            scrollbar_space = (self.SCROLLBAR_WIDTH + self.SCROLLBAR_MARGIN) if has_scroll else 0
+            content_width = viewport_width + scrollbar_space
             title_surf: pygame.Surface = section["title_surf"]
             title_height = title_surf.get_height()
             section_width = content_width + self.SECTION_PADDING * 2
-            section_height = content_height + self.SECTION_PADDING * 2 + title_height + self.SECTION_TITLE_GAP
+            section_height = viewport_height + self.SECTION_PADDING * 2 + title_height + self.SECTION_TITLE_GAP
 
             rect = section["rect"]
             rect.size = (section_width, section_height)
@@ -472,20 +491,36 @@ class MainMenuScene(C.Scene):
             title_rect.top = rect.top + self.SECTION_PADDING
             section["title_rect"] = title_rect
 
-            grid_left = rect.left + self.SECTION_PADDING
-            grid_top = title_rect.bottom + self.SECTION_TITLE_GAP
+            viewport_left = rect.left + self.SECTION_PADDING
+            extra_width = content_width - scrollbar_space - viewport_width
+            if extra_width > 0:
+                viewport_left += extra_width // 2
+            viewport_top = title_rect.bottom + self.SECTION_TITLE_GAP
+            viewport_rect = pygame.Rect(viewport_left, viewport_top, viewport_width, viewport_height)
+
+            grid_left = viewport_left
+            if actual_width and actual_width < viewport_width:
+                grid_left += (viewport_width - actual_width) // 2
+            grid_top = viewport_top
+            if actual_height and actual_height < viewport_height:
+                grid_top += (viewport_height - actual_height) // 2
 
             for index, entry in enumerate(entries):
                 col = index % columns
                 row = index // columns
                 x = grid_left + col * (self.ICON_SIZE + self.ICON_GAP)
-                y = grid_top + row * (row_height + self.ICON_GAP)
+                y = grid_top + row * row_stride
                 entry.rect.topleft = (x, y)
                 entry.label_rect.centerx = entry.rect.centerx
                 entry.label_rect.top = entry.rect.bottom + self.LABEL_MARGIN
 
             section["columns"] = columns
             section["rows"] = rows
+            section["viewport_rect"] = viewport_rect
+            section["scroll_max"] = max(0, actual_height - viewport_height)
+            section["row_stride"] = row_stride
+            section["scroll_offset"] = min(max(0, section.get("scroll_offset", 0)), section["scroll_max"])
+            section["has_scroll"] = has_scroll
 
         margin_x, margin_y = self._menu_margin
         self._menu_button_rect.topright = (C.SCREEN_W - margin_x, margin_y)
@@ -522,6 +557,27 @@ class MainMenuScene(C.Scene):
         right_center = C.SCREEN_W - self.NAV_BUTTON_RADIUS - margin
         return left_center, right_center
 
+    def _entry_icon_rect(self, section: dict, entry: _GameEntry) -> pygame.Rect:
+        offset = section.get("scroll_offset", 0)
+        return entry.rect.move(0, -offset)
+
+    def _entry_label_rect(self, section: dict, entry: _GameEntry) -> pygame.Rect:
+        offset = section.get("scroll_offset", 0)
+        return entry.label_rect.move(0, -offset)
+
+    def _scroll_section(self, section: dict, lines: int) -> None:
+        if not lines:
+            return
+        scroll_max = section.get("scroll_max", 0)
+        if scroll_max <= 0:
+            return
+        stride = section.get("row_stride", self.ICON_SIZE + self.LABEL_MARGIN + self.ICON_GAP)
+        offset = section.get("scroll_offset", 0)
+        offset = max(0, min(scroll_max, offset - lines * stride))
+        if offset != section.get("scroll_offset"):
+            section["scroll_offset"] = offset
+            self._hover_entry = None
+
     def _update_nav_rects(self):
         size = self.NAV_BUTTON_RADIUS * 2
         if not self._sections:
@@ -555,6 +611,9 @@ class MainMenuScene(C.Scene):
         if new_index == self._section_index:
             return
         self._section_index = new_index
+        new_section = self._sections[self._section_index]
+        if new_section.get("scroll_offset"):
+            new_section["scroll_offset"] = 0
         self._hover_entry = None
         self._update_nav_rects()
 
@@ -566,9 +625,13 @@ class MainMenuScene(C.Scene):
             if any(e.key == key for e in section["entries"]):
                 if idx != self._section_index:
                     self._section_index = idx
+                    target_section = self._sections[self._section_index]
+                    if target_section.get("scroll_offset"):
+                        target_section["scroll_offset"] = 0
                     self._update_nav_rects()
                 break
-        return entry.rect.copy()
+        section = self._sections[self._section_index]
+        return self._entry_icon_rect(section, entry)
 
     # --- interaction ---------------------------------------------------
     def _open_game_modal(self, game_key: str, *, proxy=None) -> bool:
@@ -650,10 +713,22 @@ class MainMenuScene(C.Scene):
             self._hover_entry = None
             if self._sections:
                 section = self._sections[self._section_index]
-                for entry in section["entries"]:
-                    if entry.rect.collidepoint(e.pos):
-                        self._hover_entry = entry
-                        break
+                viewport_rect = section.get("viewport_rect")
+                if viewport_rect is None or viewport_rect.collidepoint(e.pos):
+                    for entry in section["entries"]:
+                        icon_rect = self._entry_icon_rect(section, entry)
+                        label_rect = self._entry_label_rect(section, entry)
+                        if icon_rect.collidepoint(e.pos) or label_rect.collidepoint(e.pos):
+                            self._hover_entry = entry
+                            break
+            return
+
+        if e.type == pygame.MOUSEBUTTONDOWN and e.button in (4, 5):
+            if self._sections:
+                section = self._sections[self._section_index]
+                viewport_rect = section.get("viewport_rect")
+                if viewport_rect is None or viewport_rect.collidepoint(e.pos):
+                    self._scroll_section(section, 1 if e.button == 4 else -1)
             return
 
         if e.type == pygame.MOUSEBUTTONDOWN and e.button == 1:
@@ -668,10 +743,14 @@ class MainMenuScene(C.Scene):
                 return
             if self._sections:
                 section = self._sections[self._section_index]
-                for entry in section["entries"]:
-                    if entry.rect.collidepoint(e.pos):
-                        self._activate_entry(entry)
-                        return
+                viewport_rect = section.get("viewport_rect")
+                if viewport_rect is None or viewport_rect.collidepoint(e.pos):
+                    for entry in section["entries"]:
+                        icon_rect = self._entry_icon_rect(section, entry)
+                        label_rect = self._entry_label_rect(section, entry)
+                        if icon_rect.collidepoint(e.pos) or label_rect.collidepoint(e.pos):
+                            self._activate_entry(entry)
+                            return
         elif e.type == pygame.KEYDOWN:
             if e.key == pygame.K_ESCAPE:
                 from solitaire.scenes.title import TitleScene
@@ -680,6 +759,17 @@ class MainMenuScene(C.Scene):
                 self._change_section(-1)
             elif e.key == pygame.K_RIGHT:
                 self._change_section(1)
+        elif e.type == pygame.MOUSEWHEEL:
+            if not self._sections:
+                return
+            section = self._sections[self._section_index]
+            viewport_rect = section.get("viewport_rect")
+            if viewport_rect is None:
+                self._scroll_section(section, e.y)
+                return
+            mx, my = pygame.mouse.get_pos()
+            if viewport_rect.collidepoint((mx, my)):
+                self._scroll_section(section, e.y)
 
     # --- drawing -------------------------------------------------------
     def _draw_menu_button(self, screen):
@@ -707,10 +797,46 @@ class MainMenuScene(C.Scene):
         pygame.draw.rect(screen, self.SECTION_BORDER, rect, width=2, border_radius=self.SECTION_BORDER_RADIUS)
         title_rect = section["title_rect"]
         screen.blit(section["title_surf"], title_rect.topleft)
+        viewport_rect: pygame.Rect = section.get("viewport_rect", pygame.Rect(0, 0, 0, 0))
+        previous_clip = screen.get_clip()
+        if viewport_rect.width > 0 and viewport_rect.height > 0:
+            screen.set_clip(viewport_rect)
         for entry in section["entries"]:
-            screen.blit(entry.surface, entry.rect.topleft)
+            icon_rect = self._entry_icon_rect(section, entry)
+            label_rect = self._entry_label_rect(section, entry)
+            if viewport_rect.width > 0 and viewport_rect.height > 0 and not viewport_rect.colliderect(icon_rect):
+                if not viewport_rect.colliderect(label_rect):
+                    continue
+            if entry.surface is not None:
+                screen.blit(entry.surface, icon_rect.topleft)
             if entry.label_surf is not None:
-                screen.blit(entry.label_surf, entry.label_rect.topleft)
+                screen.blit(entry.label_surf, label_rect.topleft)
+        if viewport_rect.width > 0 and viewport_rect.height > 0:
+            screen.set_clip(previous_clip)
+
+        if section.get("scroll_max", 0) > 0 and viewport_rect.height > 0:
+            track_rect = pygame.Rect(
+                viewport_rect.right + self.SCROLLBAR_MARGIN,
+                viewport_rect.top,
+                self.SCROLLBAR_WIDTH,
+                viewport_rect.height,
+            )
+            pygame.draw.rect(screen, (220, 220, 225), track_rect, border_radius=self.SCROLLBAR_WIDTH // 2)
+            content_height = viewport_rect.height + section["scroll_max"]
+            if content_height > 0:
+                thumb_height = max(32, int(viewport_rect.height * viewport_rect.height / content_height))
+                thumb_travel = max(0, track_rect.height - thumb_height)
+                offset = section.get("scroll_offset", 0)
+                thumb_top = track_rect.top
+                if thumb_travel > 0 and section["scroll_max"] > 0:
+                    thumb_top += int(thumb_travel * (offset / section["scroll_max"]))
+                thumb_rect = pygame.Rect(
+                    track_rect.left,
+                    thumb_top,
+                    track_rect.width,
+                    thumb_height,
+                )
+                pygame.draw.rect(screen, (150, 150, 160), thumb_rect, border_radius=self.SCROLLBAR_WIDTH // 2)
 
     def _draw_nav_button(self, screen, rect: pygame.Rect, direction: int, enabled: bool, hover: bool) -> None:
         if rect.width <= 0 or rect.height <= 0 or not enabled and len(self._sections) <= 1:


### PR DESCRIPTION
## Summary
- ensure menu sections allocate space for a consistent 3x3 grid viewport
- add per-section scrolling with wheel support and draw a scrollbar when needed
- adjust hit testing and drawing to account for the scrolled entry positions

## Testing
- python -m compileall src/solitaire/scenes/menu.py

------
https://chatgpt.com/codex/tasks/task_e_68df23931ff48321b0519cceabff6c70