### PR TITLE
Fix La Duchesse de Luynes toolbar layout typo

### DIFF
--- a/src/solitaire/modes/duchess_de_luynes.py
+++ b/src/solitaire/modes/duchess_de_luynes.py
@@ -279,7 +279,11 @@ class LaDuchesseDeLuynesGameScene(C.Scene):
             pile.y = bottom_y
 
         if self.toolbar:
-            self.toolbar.reflow()
+            # The shared toolbar exposes a ``relayout`` helper (matching other
+            # modes such as Monte Carlo). The previous call to ``reflow`` was a
+            # typo which caused an ``AttributeError`` when the scene initialised
+            # via the menu options controller.
+            self.toolbar.relayout()
 
     # ------------------------------------------------------------------
     # Game setup & persistence


### PR DESCRIPTION
## Summary
- correct the toolbar layout call in the La Duchesse de Luynes scene
- add inline context explaining the previous AttributeError

## Testing
- python -m compileall src/solitaire/modes/duchess_de_luynes.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c130c4b083218a10696e48908523