### PR TITLE
Refine Duchesse de Luynes foundation placeholders

### DIFF
--- a/src/solitaire/modes/duchess_de_luynes.py
+++ b/src/solitaire/modes/duchess_de_luynes.py
@@ -622,6 +622,8 @@ class LaDuchesseDeLuynesGameScene(C.Scene):
         for pile in self.top_foundations + self.bottom_foundations + self.tableau + [self.stock_pile, self.reserve_pile]:
             pile.draw(surface)
 
+        self._draw_foundation_placeholders(surface)
+
         self._draw_labels(surface)
         self._draw_highlights(surface)
 
@@ -640,6 +642,46 @@ class LaDuchesseDeLuynesGameScene(C.Scene):
         self.ui_helper.draw_menu_modal(surface)
 
         self.end_modal.draw(surface)
+
+    def _draw_foundation_placeholders(self, surface: pygame.Surface) -> None:
+        corner_font = C.FONT_CORNER_RANK or pygame.font.SysFont(pygame.font.get_default_font(), 26, bold=True)
+        suit_font = C.FONT_CENTER_SUIT or pygame.font.SysFont(pygame.font.get_default_font(), 64)
+        color = (245, 245, 250)
+        pad_x = max(6, C.CARD_W // 12)
+        pad_y = max(6, C.CARD_H // 12)
+
+        def draw_corner_markers(pile: C.Pile, text: str) -> None:
+            if pile.cards:
+                return
+            marker = corner_font.render(text, True, color)
+            surface.blit(marker, (pile.x + pad_x, pile.y + pad_y))
+            surface.blit(
+                marker,
+                (
+                    pile.x + C.CARD_W - marker.get_width() - pad_x,
+                    pile.y + C.CARD_H - marker.get_height() - pad_y,
+                ),
+            )
+
+        def draw_suit_symbol(pile: C.Pile, suit_index: int) -> None:
+            if pile.cards:
+                return
+            suit_char = C.SUITS[suit_index]
+            suit_surface = suit_font.render(suit_char, True, color)
+            surface.blit(
+                suit_surface,
+                (
+                    pile.x + C.CARD_W // 2 - suit_surface.get_width() // 2,
+                    pile.y + C.CARD_H // 2 - suit_surface.get_height() // 2,
+                ),
+            )
+
+        for idx, pile in enumerate(self.top_foundations):
+            draw_suit_symbol(pile, self.FOUNDATION_ORDER[idx])
+            draw_corner_markers(pile, "K")
+        for idx, pile in enumerate(self.bottom_foundations):
+            draw_suit_symbol(pile, self.FOUNDATION_ORDER[idx])
+            draw_corner_markers(pile, "A")
 
     def _draw_labels(self, surface: pygame.Surface) -> None:
         label_font = C.FONT_UI or pygame.font.SysFont(pygame.font.get_default_font(), 26, bold=True)


### PR DESCRIPTION
## Summary
- render suit icons within the empty foundation placeholders so they match Klondike styling
- overlay "K" markers on empty top foundations and "A" markers on empty bottom foundations for rank guidance

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68e2c22e4a68832192eeb021fd44e992