### PR TITLE
Stop reopening game options when returning to menu

### DIFF
--- a/src/solitaire/modes/base_scene.py
+++ b/src/solitaire/modes/base_scene.py
@@ -451,11 +451,6 @@ class ModeUIHelper:
         from solitaire.scenes.menu import MainMenuScene
 
         menu_scene = MainMenuScene(self.scene.app)
-        if self._game_id:
-            try:
-                menu_scene._open_game_modal(self._game_id)
-            except Exception:
-                pass
         self.scene.next_scene = menu_scene
 
     def handle_shortcuts(self, event) -> bool:

--- a/src/solitaire/modes/golf.py
+++ b/src/solitaire/modes/golf.py
@@ -779,19 +779,11 @@ class GolfScoresScene(C.Scene):
                 from solitaire.scenes.menu import MainMenuScene
 
                 menu_scene = MainMenuScene(self.app)
-                try:
-                    menu_scene._open_game_modal("golf")
-                except Exception:
-                    pass
                 self.next_scene = menu_scene
         elif e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
             from solitaire.scenes.menu import MainMenuScene
 
             menu_scene = MainMenuScene(self.app)
-            try:
-                menu_scene._open_game_modal("golf")
-            except Exception:
-                pass
             self.next_scene = menu_scene
 
     def draw(self, screen):


### PR DESCRIPTION
## Summary
- prevent in-game menu exits from reopening the previous game's options modal when returning to the main menu
- ensure Golf scores scene returns to the main menu without popping the Golf options modal

## Testing
- pytest tests/unit_tests/test_app_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68e39912b0108321977d7bc8b4d18198